### PR TITLE
Release v0.8.0: Capability abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A framework for building AI agents using the OpenAI Agents SDK. Fork this reposi
 - **Tool Catalog** - Load tool metadata (description, category, recovery hints) from a YAML file
 - **Knowledge Store** - Inject domain knowledge from YAML files into agent system prompts
 - **Structured Agent-as-Tool** - Typed input schemas and structured error handling for sub-agent calls
+- **Capabilities** - Pluggable agent behaviors (turn budgets, error recovery, custom hooks) - write a `Capability` subclass and attach it to an `AgentDefinition`. See [`documentation/project/capabilities.md`](documentation/project/capabilities.md).
 - **MCP Server** - Expose registered tools as an MCP server (stdio or HTTP) with zero description duplication - all metadata comes from `tools.yaml`
 
 ## Installation
@@ -672,6 +673,38 @@ This is handled by `structured_tool_error()`, which is automatically wired into 
 3. If `as_tool_turn_budget` is set, wires up `TurnBudgetHooks` and dynamic instructions (see [Turn budget for sub-agents](#turn-budget-for-sub-agents-agent-as-tool))
 
 No manual wiring needed - just set `as_tool_parameters` on your `AgentDefinition`.
+
+## Extending sinan-agentic — Custom Capabilities
+
+`Capability` is the extension point for cross-cutting agent behavior. Write a subclass, attach it to an `AgentDefinition`, and the runtime calls its lifecycle hooks (and merges its instruction fragments into the system prompt) for every run. Both `TurnBudget` and `ToolErrorRecovery` are themselves `Capability` subclasses - see them for reference.
+
+```python
+from agents import RunContextWrapper, Tool
+from sinan_agentic_core import Capability, AgentDefinition, register_agent
+
+
+class ToolCallLogger(Capability):
+    """Print every tool call - useful as a debugging aid."""
+
+    def on_tool_start(self, ctx: RunContextWrapper, tool: Tool, args: str) -> None:
+        print(f"[tool] -> {tool.name}({args})")
+
+    def on_tool_end(self, ctx: RunContextWrapper, tool: Tool, result: str) -> None:
+        print(f"[tool] <- {tool.name}: {result[:120]}")
+
+
+register_agent(AgentDefinition(
+    name="time_assistant",
+    description="Tells the time",
+    instructions="You are a helpful assistant.",
+    tools=["get_current_time"],
+    capabilities=[ToolCallLogger()],
+))
+```
+
+The runner clones each declared capability per run (so concurrent runs are isolated), calls `reset()` on the clones, then composes them into a single `RunHooks` adapter. Override only the hook methods you care about - everything else is a no-op by default.
+
+For the full lifecycle reference, the protocol surface, and migration notes for existing direct-Python and YAML users, see [`documentation/project/capabilities.md`](documentation/project/capabilities.md). For a runnable end-to-end example, see [`examples/custom_capability.py`](examples/custom_capability.py).
 
 ## Tool Error Recovery
 

--- a/README.md
+++ b/README.md
@@ -1016,10 +1016,14 @@ sinan_agentic_core/
 ├── __init__.py              # Main exports
 ├── orchestrator.py          # Multi-agent orchestration
 ├── core/
-│   ├── base_runner.py       # BaseAgentRunner
-│   ├── errors.py            # structured_tool_error for agent-as-tool failures
-│   ├── turn_budget.py       # TurnBudget + TurnBudgetHooks (soft turn management)
-│   └── turn_budget_tool.py  # request_extension tool (agent self-approval)
+│   ├── base_runner.py            # BaseAgentRunner
+│   ├── capabilities/             # Capability protocol (pluggable agent behaviors)
+│   │   ├── __init__.py
+│   │   └── base.py               # Capability base class + lifecycle hooks
+│   ├── errors.py                 # structured_tool_error for agent-as-tool failures
+│   ├── tool_error_recovery.py    # ToolErrorRecovery capability
+│   ├── turn_budget.py            # TurnBudget capability + TurnBudgetHooks
+│   └── turn_budget_tool.py       # request_extension tool (agent self-approval)
 ├── instructions/
 │   └── builder.py           # InstructionBuilder base class
 ├── mcp/                        # MCP server support (optional, requires sinan-agentic-core[mcp])
@@ -1029,11 +1033,12 @@ sinan_agentic_core/
 │   ├── tool_adapter.py         # Wraps registered tools for MCP invocation
 │   └── yaml_schema.py          # Pydantic models for MCP YAML config
 ├── registry/
-│   ├── agent_catalog.py     # YAML-driven agent catalog + MCP server definitions
-│   ├── agent_registry.py    # AgentDefinition + registry
-│   ├── agent_factory.py     # create_agent_from_registry()
-│   ├── tool_catalog.py      # YAML-driven tool catalog + MCP exposure flags
-│   ├── tool_registry.py     # ToolDefinition + registry
+│   ├── agent_catalog.py        # YAML-driven agent catalog + MCP server definitions
+│   ├── agent_registry.py       # AgentDefinition + registry
+│   ├── agent_factory.py        # create_agent_from_registry()
+│   ├── capability_registry.py  # @register_capability + named capability factories
+│   ├── tool_catalog.py         # YAML-driven tool catalog + MCP exposure flags
+│   ├── tool_registry.py        # ToolDefinition + registry
 │   └── guardrail_registry.py
 ├── services/
 │   ├── chat.py              # chat(), chat_with_hooks(), chat_streamed()

--- a/documentation/project/brainstorm/capability-epic-issues.md
+++ b/documentation/project/brainstorm/capability-epic-issues.md
@@ -1,0 +1,322 @@
+# Capability Pattern - Epic & Child Issues
+
+> Ready-to-post GitHub issues for `thomaspernet/sinan-agentic`.
+> Source briefing: `capability-epic-briefing.md`.
+
+**Suggested labels for all issues:** `capability-pattern`
+**Per-issue labels:** noted inline.
+
+---
+
+## EPIC
+
+**Title:** `[EPIC] Introduce Capability abstraction for pluggable agent behaviors`
+
+**Labels:** `epic`, `capability-pattern`, `enhancement`
+
+**Body:**
+
+### Vision
+
+Today, cross-cutting agent behaviors (turn budgets, tool-error recovery) are hardcoded inside `_CompositeHooks` in `sinan_agentic_core/core/base_runner.py:1037-1073`. Each new behavior - skills, compaction, memory, audit logging - requires editing `base_runner.py` again.
+
+OpenAI's Agents SDK 0.14 (released 2026-04-15) introduced `agents.sandbox.Capability` as a clean primitive for exactly this kind of pluggable behavior. We've already built this pattern by hand twice (`TurnBudget`, `ToolErrorRecovery`); it's time to extract it.
+
+### Goals
+
+- Define a `Capability` protocol whose shape mirrors OpenAI's so future interop is cheap.
+- Refactor `TurnBudget` and `ToolErrorRecovery` to implement it - **zero behavior change** for current users.
+- Make capabilities pluggable via `AgentDefinition.capabilities` and the YAML catalog.
+- Establish the extension point so adding a new behavior is "write a `Capability` subclass" instead of "edit `base_runner.py`."
+
+### Non-goals (explicitly deferred)
+
+- No `Manifest`, `Workspace`, sandbox client, or filesystem-isolation concept.
+- No dependency on OpenAI's `agents.sandbox.*` internals.
+- No backward-compat shims for renamed/removed helpers - dead code gets deleted.
+- Snapshot/rehydrate is a **stretch** issue (#7); fine to ship the epic without it.
+
+### Child issues (in dependency order)
+
+- [ ] #1 - Define `Capability` protocol and base class (S)
+- [ ] #2 - Refactor `TurnBudget` to implement `Capability` (M)
+- [ ] #3 - Refactor `ToolErrorRecovery` to implement `Capability` (M)
+- [ ] #4 - Wire `capabilities` field into `AgentDefinition` and generalize `_CompositeHooks` (M)
+- [ ] #5 - YAML registry support for capabilities (M)
+- [ ] #6 - Migration notes, custom-capability example, README update (S)
+- [ ] #7 - **(Stretch)** Capability snapshot/rehydrate via `SQLiteSessionStore` (L)
+
+**Dependency graph:** `1 -> (2, 3 in parallel) -> 4 -> 5 -> 6`. `7` depends on `4`, otherwise independent.
+
+### Success criteria
+
+- `pytest` is green at every issue boundary; no test regressions in `tests/test_turn_budget.py` or `tests/test_tool_error_recovery.py`.
+- `mypy --strict sinan_agentic_core` passes.
+- Adding a new capability requires **no edits** to `base_runner.py` after #4 lands.
+
+### References
+
+- Briefing: `documentation/project/brainstorm/capability-epic-briefing.md`
+- OpenAI blog: https://openai.com/index/the-next-evolution-of-the-agents-sdk/
+- SDK reference: https://openai.github.io/openai-agents-python/ref/sandbox/
+
+---
+
+## ISSUE 1 - Define `Capability` protocol and base class
+
+**Title:** `feat(capabilities): define Capability protocol and base class`
+
+**Labels:** `capability-pattern`, `enhancement`
+
+**Complexity:** S
+
+**Depends on:** none
+
+**Description:**
+
+Pure addition. Create the `Capability` protocol that subsequent issues will implement. No refactor of existing code in this issue.
+
+### Implementation
+
+- New module: `sinan_agentic_core/core/capabilities/__init__.py`
+- New module: `sinan_agentic_core/core/capabilities/base.py`
+- Define `Capability` (ABC or `Protocol` - choose whichever type-checks more cleanly under `mypy --strict`) with:
+  - `instructions(self, ctx) -> str | None` - contribute a fragment to the system prompt; return `None` to contribute nothing.
+  - `on_tool_start(self, ctx, tool, args) -> None` - default no-op.
+  - `on_tool_end(self, ctx, tool, result) -> None` - default no-op.
+  - `reset(self) -> None` - called at the start of each `execute()` call; default no-op.
+  - `clone(self) -> "Capability"` - per-run copy; capabilities are stateful and must not leak across runs.
+  - Optional: `tools(self) -> list[Tool]` - default `[]`. Reserved for future use.
+
+### Acceptance criteria
+
+- [ ] `from sinan_agentic_core.core.capabilities import Capability` succeeds.
+- [ ] A trivial `DummyCapability(Capability)` in tests type-checks under `mypy --strict`.
+- [ ] Unit tests in `tests/core/capabilities/test_base.py` cover: default no-op behavior of every lifecycle method, `clone()` returns an independent instance, `reset()` callable.
+- [ ] `pytest` and `mypy --strict sinan_agentic_core` both pass.
+
+---
+
+## ISSUE 2 - Refactor `TurnBudget` to implement `Capability`
+
+**Title:** `refactor(capabilities): make TurnBudget a Capability`
+
+**Labels:** `capability-pattern`, `refactor`
+
+**Complexity:** M
+
+**Depends on:** #1
+
+**Description:**
+
+Adopt the `Capability` protocol on the existing `TurnBudget` class in `sinan_agentic_core/core/turn_budget.py`. **No behavior change.** This is purely a protocol-adoption refactor.
+
+### Implementation
+
+- `class TurnBudget(Capability):` (or implements the Protocol).
+- Map existing methods to capability lifecycle:
+  - `instructions(ctx)` -> wraps the existing `build_instruction_section()`.
+  - `reset()` -> wraps the existing `reset()`.
+  - `clone()` -> returns a fresh `TurnBudget` with the same configuration but zeroed counters.
+- Public constructor and existing public methods stay unchanged - users importing `TurnBudget` directly see no break.
+- Delete any helper paths that become dead after the refactor (per project rule: no backward-compat shims).
+
+### Acceptance criteria
+
+- [ ] `TurnBudget` satisfies the `Capability` protocol (verified by a `isinstance` / `issubclass` test or `mypy` check).
+- [ ] All existing tests in `tests/test_turn_budget.py` pass **unchanged**.
+- [ ] New test confirms `clone()` produces an independent instance with the same config but reset state.
+- [ ] No diff in `base_runner.py` yet - that's #4.
+- [ ] `pytest` and `mypy --strict` pass.
+
+---
+
+## ISSUE 3 - Refactor `ToolErrorRecovery` to implement `Capability`
+
+**Title:** `refactor(capabilities): make ToolErrorRecovery a Capability`
+
+**Labels:** `capability-pattern`, `refactor`
+
+**Complexity:** M
+
+**Depends on:** #1
+
+**Description:**
+
+Same shape as #2 but for `ToolErrorRecovery` in `sinan_agentic_core/core/tool_error_recovery.py`. Can be done in parallel with #2.
+
+### Implementation
+
+- `class ToolErrorRecovery(Capability):` (or implements the Protocol).
+- Map existing methods:
+  - `instructions(ctx)` -> wraps existing instruction-building helper.
+  - `on_tool_end(ctx, tool, result)` -> wraps existing `RunHooks.on_tool_end` logic that records errors.
+  - `reset()` -> clears the per-run error tally.
+  - `clone()` -> fresh instance with same config, zeroed error state.
+- Public API preserved. Dead helpers deleted.
+
+### Acceptance criteria
+
+- [ ] `ToolErrorRecovery` satisfies the `Capability` protocol.
+- [ ] All existing tests in `tests/test_tool_error_recovery.py` pass **unchanged**.
+- [ ] New test confirms `clone()` independence.
+- [ ] No diff in `base_runner.py` yet.
+- [ ] `pytest` and `mypy --strict` pass.
+
+---
+
+## ISSUE 4 - Wire `capabilities` into `AgentDefinition` and generalize `_CompositeHooks`
+
+**Title:** `feat(capabilities): pluggable capabilities on AgentDefinition`
+
+**Labels:** `capability-pattern`, `enhancement`, `refactor`
+
+**Complexity:** M
+
+**Depends on:** #2, #3
+
+**Description:**
+
+This is the integration step. After this lands, adding a new behavior requires no edits to `base_runner.py`.
+
+### Implementation
+
+- `sinan_agentic_core/registry/agent_registry.py` - add to `AgentDefinition`:
+  ```python
+  capabilities: list[Capability] = field(default_factory=list)
+  ```
+- `sinan_agentic_core/core/base_runner.py:1037-1073` - `_CompositeHooks` no longer references `TurnBudget` or `ToolErrorRecovery` by name. It iterates `agent_def.capabilities` and dispatches `on_tool_start` / `on_tool_end` / etc. to each.
+- `sinan_agentic_core/core/base_runner.py:860-926` - `_apply_dynamic_instructions()` merges all `capability.instructions(ctx)` fragments (in registration order; skip `None`s).
+- `sinan_agentic_core/core/base_runner.py:91-151` - `create_agent()` calls `capability.clone()` once per run for each capability and uses the clones for that run's hooks (per-run isolation).
+- Reset all per-run capability state at the top of `execute()` via `capability.reset()`.
+- **Delete** the now-unreachable hardcoded `TurnBudget` / `ToolErrorRecovery` branches in `_CompositeHooks` and the dynamic-instructions builder.
+
+### Acceptance criteria
+
+- [ ] Existing integration tests pass with **no behavior change** when `TurnBudget(...)` and `ToolErrorRecovery(...)` are passed in `AgentDefinition.capabilities`.
+- [ ] New test: a custom `LoggingCapability` (records every `on_tool_start` call) wired via `capabilities=[LoggingCapability()]` is invoked correctly without any `base_runner.py` edits.
+- [ ] New test: capability state does not leak across two sequential `execute()` calls (verifies `clone()` + `reset()`).
+- [ ] `_CompositeHooks` no longer mentions `TurnBudget` or `ToolErrorRecovery` by name.
+- [ ] `pytest` (with coverage gate) and `mypy --strict` pass.
+
+---
+
+## ISSUE 5 - YAML registry support for capabilities
+
+**Title:** `feat(capabilities): YAML catalog support and CapabilityRegistry`
+
+**Labels:** `capability-pattern`, `enhancement`
+
+**Complexity:** M
+
+**Depends on:** #4
+
+**Description:**
+
+Make capabilities declarable from `agents.yaml` so users don't need Python wiring.
+
+### Implementation
+
+- New module: `sinan_agentic_core/registry/capability_registry.py` - `CapabilityRegistry` parallel to `ToolRegistry`. Decorator `@register_capability("name")` to register a `Capability` factory.
+- `sinan_agentic_core/registry/agent_catalog.py:54-89` - parse a `capabilities:` block on each agent entry. Two supported forms:
+  - Built-in shorthand keys (resolved into the corresponding factory automatically):
+    ```yaml
+    turn_budget:
+      max_turns: 10
+    error_recovery:
+      max_consecutive_errors: 3
+    ```
+  - Explicit list referencing registered names:
+    ```yaml
+    capabilities:
+      - name: turn_budget
+        config: { max_turns: 10 }
+      - name: my_custom_capability
+    ```
+- Built-in shorthands `turn_budget` and `error_recovery` register on import.
+- Validate at load time: unknown capability name -> clear `CapabilityNotFoundError`.
+
+### Acceptance criteria
+
+- [ ] `tests/registry/test_capability_registry.py` covers: registration, lookup, unknown-name error, factory invocation with config.
+- [ ] `tests/registry/test_agent_catalog.py` covers: both YAML forms, mixing shorthand and explicit list, validation errors.
+- [ ] An example YAML in `examples/` exercises a capability declared from YAML.
+- [ ] `pytest` and `mypy --strict` pass.
+
+---
+
+## ISSUE 6 - Migration notes, custom-capability example, README update
+
+**Title:** `docs(capabilities): migration notes, custom example, README extension section`
+
+**Labels:** `capability-pattern`, `documentation`
+
+**Complexity:** S
+
+**Depends on:** #5
+
+**Description:**
+
+Document the new extension point. The migration story should be near-zero-change for existing users.
+
+### Implementation
+
+- `documentation/project/capabilities.md` (new) - protocol overview, lifecycle diagram (text is fine), how to write a custom capability.
+- Update `README.md` "Extending sinan-agentic" section with a short capability example (e.g., a `ToolCallLogger` capability that prints every tool call).
+- `examples/custom_capability.py` - runnable end-to-end sample.
+- Migration notes section: existing `TurnBudget` / `ToolErrorRecovery` users see no change; YAML users get the new `capabilities:` block.
+
+### Acceptance criteria
+
+- [ ] `examples/custom_capability.py` runs without error.
+- [ ] README links to the new docs page.
+- [ ] Migration notes explicitly state "no required changes" for existing direct-Python users.
+- [ ] `pytest` (in case the example is exercised) passes.
+
+---
+
+## ISSUE 7 - (Stretch) Capability snapshot/rehydrate
+
+**Title:** `feat(capabilities): durable snapshot/rehydrate via SQLiteSessionStore`
+
+**Labels:** `capability-pattern`, `enhancement`, `stretch`
+
+**Complexity:** L
+
+**Depends on:** #4 (independent of #5, #6)
+
+**Description:**
+
+Optional follow-up: persist capability state across process restarts so a session can resume a long-running agent mid-budget, mid-recovery, etc.
+
+### Implementation
+
+- Extend the `Capability` protocol with **optional** methods:
+  - `to_snapshot(self) -> dict | None` - default returns `None` (capability is stateless / not durable).
+  - `from_snapshot(self, data: dict) -> None` - default no-op.
+- `TurnBudget` and `ToolErrorRecovery` implement both; serialize their counters.
+- `sinan_agentic_core/session/sqlite_store.py` - persist a JSON blob per capability per session row.
+- `sinan_agentic_core/session/agent_session.py` - on session load, call `from_snapshot()` for each capability whose snapshot is present.
+
+### Acceptance criteria
+
+- [ ] Round-trip test: configure a `TurnBudget` to 10 turns, advance counter to 4, snapshot, rehydrate in a new session, confirm 6 turns remain.
+- [ ] Same round-trip for `ToolErrorRecovery`.
+- [ ] Capabilities without snapshot support continue to work (no crash, no persistence).
+- [ ] Schema migration for `SQLiteSessionStore` is forward-only and documented.
+- [ ] `pytest` and `mypy --strict` pass.
+
+---
+
+## Posting
+
+If you want to post these via `gh`:
+
+```bash
+# From repo root, with gh authenticated
+gh issue create --repo thomaspernet/sinan-agentic \
+  --title "[EPIC] Introduce Capability abstraction for pluggable agent behaviors" \
+  --label epic,capability-pattern,enhancement \
+  --body-file <(sed -n '/^## EPIC/,/^---$/p' documentation/project/brainstorm/capability-epic-issues.md)
+# ... repeat per child issue, then edit the epic body to substitute real issue numbers for the #1..#7 placeholders.
+```

--- a/documentation/project/capabilities.md
+++ b/documentation/project/capabilities.md
@@ -38,6 +38,8 @@ The full surface lives in `sinan_agentic_core/core/capabilities/base.py`:
 | `tools()` | Extra tools the capability exposes to the agent |
 | `reset()` | Called at the start of every `execute()` - clear mutable state |
 | `clone()` | Per-run copy; default is `copy.deepcopy(self)` |
+| `to_snapshot()` | Return a JSON-serializable dict of mutable state, or `None` to opt out of persistence |
+| `from_snapshot(data)` | Rehydrate state from a dict produced by `to_snapshot()` |
 
 A capability may also assign `self.on_event = callback` to emit custom
 streaming events. The runtime sets this on cloned capabilities when streaming.
@@ -282,12 +284,32 @@ await runner.execute(
 Both forms produce the same effective capability list. Runtime kwargs still
 win when you need to inspect post-run state.
 
-**YAML users.** The current `agents.yaml` schema continues to use the
-`turn_budget:` block and the `error_recovery: bool` flag - those keep
-working as a convenience for the two built-in capabilities. A general
-`capabilities:` YAML block (for arbitrary user-defined capabilities) is the
-next planned increment; until it lands, attach custom capabilities in
-Python after loading the catalog:
+**YAML users.** The `agents.yaml` schema supports capabilities through
+two paths that compose in a single agent entry:
+
+- `turn_budget:` and `error_recovery:` shorthand keys — same as before,
+  resolved into the two built-in capabilities.
+- An explicit `capabilities:` list — references any name registered in
+  the [`CapabilityRegistry`](#yaml-capabilities). Built-ins are
+  pre-registered; custom capabilities register via
+  `@register_capability("name")`.
+
+```yaml
+# agents.yaml
+agents:
+  research_agent:
+    model: gpt-4o
+    description: Deep research
+    max_turns: 25
+    turn_budget:
+      default_turns: 10
+      reminder_at: 2
+    error_recovery: true
+    capabilities:
+      - name: audit_log
+        config:
+          label: research-run
+```
 
 ```python
 catalog = load_agent_catalog("agents.yaml")
@@ -299,13 +321,106 @@ register_agent(AgentDefinition(
     description=cfg.description,
     tools=cfg.tools,
     instructions=build_instructions,
-    capabilities=[
-        cfg.build_turn_budget(),
-        cfg.build_error_recovery(),
-        ToolCallLogger(),
-    ],
+    capabilities=cfg.build_capabilities(),
 ))
 ```
+
+`build_capabilities()` resolves both shorthand keys and the explicit
+list in that order. Unknown capability names raise
+`CapabilityNotFoundError` at `catalog.get()` time, so typos surface at
+startup rather than mid-run.
+
+## YAML capabilities
+
+Custom capabilities reach `agents.yaml` through the
+`CapabilityRegistry`. A factory takes a config dict (whatever the YAML
+entry's `config:` mapping holds) and returns a `Capability` instance.
+
+```python
+from sinan_agentic_core import register_capability, Capability
+
+
+@register_capability("audit_log")
+def build_audit_log(config: dict) -> Capability:
+    return AuditLog(**config)
+```
+
+Once the factory is registered (decorator runs at import time), the
+name is referenceable from any `agents.yaml`:
+
+```yaml
+agents:
+  scribe:
+    model: gpt-4o-mini
+    description: Demo agent
+    capabilities:
+      - name: audit_log
+        config:
+          label: scribe-run
+      - name: turn_budget          # built-ins work the same way
+        config:
+          default_turns: 5
+```
+
+Two registry rules worth knowing:
+
+- Re-registering a name overwrites the previous factory (last wins).
+  Useful for tests; surprising in production — keep names unique.
+- The two built-ins (`turn_budget`, `error_recovery`) are registered on
+  `import sinan_agentic_core.registry.capability_registry`. Custom
+  factories are usually placed next to the capability class so the
+  registration runs as soon as that module is imported.
+
+The runnable example lives at `examples/yaml_capabilities/run.py`.
+
+## Snapshot and rehydrate
+
+A capability that wants its state to survive a process restart
+overrides two methods:
+
+```python
+class TurnBudget(Capability):
+    def to_snapshot(self) -> dict[str, int] | None:
+        return {
+            "turns_used": self.turns_used,
+            "extensions_used": self.extensions_used,
+        }
+
+    def from_snapshot(self, data: dict) -> None:
+        self.turns_used = data.get("turns_used", 0)
+        self.extensions_used = data.get("extensions_used", 0)
+```
+
+Capabilities that return `None` from `to_snapshot()` are treated as
+stateless and skipped — that is the default, so nothing changes for
+existing capabilities.
+
+`AgentSession` provides two helpers to drive persistence against a
+`SQLiteSessionStore`:
+
+```python
+from sinan_agentic_core import AgentSession, SQLiteSessionStore
+
+store = SQLiteSessionStore("data/conversations.db")
+session = AgentSession(session_id="user-123")
+
+# Before the run: pull any saved blobs back into the capabilities.
+session.rehydrate_capabilities(store, agent_def.capabilities)
+
+# After the run: write each opt-in capability's snapshot.
+session.persist_capabilities(store, agent_def.capabilities)
+```
+
+Snapshots key off the capability's fully-qualified class name by
+default, so two capabilities of the same type collapse to one row per
+session. Subclasses that need per-instance separation set
+`self.snapshot_key = "..."` on the instance.
+
+The dedicated table is `capability_snapshots(session_id,
+capability_key, snapshot, updated_at)`. Each save upserts on the
+composite primary key; clearing or archiving a session leaves
+snapshots untouched unless you call
+`store.delete_capability_snapshots(session_id)`.
 
 ## Reference
 
@@ -316,4 +431,11 @@ register_agent(AgentDefinition(
   `sinan_agentic_core/core/base_runner.py:1051`
 - Built-ins: `sinan_agentic_core/core/turn_budget.py`,
   `sinan_agentic_core/core/tool_error_recovery.py`
-- Runnable example: `examples/custom_capability.py`
+- YAML registry: `sinan_agentic_core/registry/capability_registry.py`
+- YAML wiring: `AgentYamlEntry.build_capabilities` in
+  `sinan_agentic_core/registry/agent_catalog.py`
+- Snapshot store: `SQLiteSessionStore.save_capability_snapshot` /
+  `load_all_capability_snapshots` in
+  `sinan_agentic_core/session/sqlite_store.py`
+- Runnable examples: `examples/custom_capability.py`,
+  `examples/yaml_capabilities/run.py`

--- a/documentation/project/capabilities.md
+++ b/documentation/project/capabilities.md
@@ -1,0 +1,319 @@
+# Capabilities
+
+`Capability` is the extension point for cross-cutting agent behavior - turn
+budgets, tool-error recovery, audit logging, memory, compaction, anything
+that needs to react to lifecycle events or contribute to the system prompt.
+
+Before this primitive existed, every new behavior meant editing
+`base_runner.py` and adding another bespoke `RunHooks` adapter. Now adding a
+behavior is "write a `Capability` subclass and attach it to an
+`AgentDefinition`" - no runner edits required.
+
+The shape mirrors the OpenAI Agents SDK `sandbox.Capability` (clone, bind,
+instructions) so future interop is cheap, but the class has no dependency on
+sandbox internals.
+
+## Protocol overview
+
+A capability is a stateful object with two roles:
+
+1. **React to lifecycle events** via `on_*` hook methods. Default
+   implementations are no-ops, so subclasses override only what they need.
+2. **Contribute to the system prompt** via `instructions(ctx)`, which returns
+   a fragment merged into the agent's instructions before each LLM call.
+   Return `None` to contribute nothing this turn.
+
+The full surface lives in `sinan_agentic_core/core/capabilities/base.py`:
+
+| Method | When it fires |
+|---|---|
+| `instructions(ctx)` | Before each LLM call - return a fragment or `None` |
+| `on_agent_start(ctx, agent)` | Run begins |
+| `on_agent_end(ctx, agent, output)` | Run ends with a final output |
+| `on_handoff(ctx, from_agent, to_agent)` | Control hands off between agents |
+| `on_tool_start(ctx, tool, args)` | Tool is about to execute |
+| `on_tool_end(ctx, tool, result)` | Tool finished |
+| `on_llm_start(ctx, agent, system_prompt, input_items)` | Model call begins |
+| `on_llm_end(ctx, agent, response)` | Model call returns |
+| `tools()` | Extra tools the capability exposes to the agent |
+| `reset()` | Called at the start of every `execute()` - clear mutable state |
+| `clone()` | Per-run copy; default is `copy.deepcopy(self)` |
+
+A capability may also assign `self.on_event = callback` to emit custom
+streaming events. The runtime sets this on cloned capabilities when streaming.
+
+## Lifecycle
+
+```text
+AgentDefinition(capabilities=[A, B])
+   |
+   v
+runner.execute(...)
+   |
+   |-- _build_run_capabilities():  for each declared cap -> cap.clone()
+   |                               then cap.reset() on every effective cap
+   |
+   |-- _apply_dynamic_instructions(): wraps agent.instructions so each turn
+   |                                  appends instructions(ctx) fragments
+   |
+   |-- _CompositeHooks(caps):       routes SDK RunHooks events to every
+   |                                capability's matching on_* method
+   |
+   v
+Runner.run(...)
+   |
+   |-- on_agent_start  -> A.on_agent_start, B.on_agent_start
+   |-- on_llm_start    -> A.on_llm_start, B.on_llm_start
+   |   (system prompt now includes A.instructions + B.instructions fragments)
+   |-- on_tool_start / on_tool_end -> ...
+   |-- on_llm_end
+   |-- on_agent_end
+   v
+final_output (caps still hold post-run state for inspection)
+```
+
+The cloning rule is the key isolation guarantee: declarative capabilities on
+`AgentDefinition` are templates, the runner clones them per call, so two
+concurrent runs never share `turns_used` or error history.
+
+## Writing a custom capability
+
+Override only the hooks you need. Everything else is a no-op.
+
+```python
+from agents import RunContextWrapper, Tool
+from sinan_agentic_core import Capability
+
+
+class ToolCallLogger(Capability):
+    """Print every tool call - args in, result out.
+
+    Useful as a debugging aid during development. Drop it in via
+    AgentDefinition.capabilities and watch the trace as the agent runs.
+    """
+
+    def __init__(self, prefix: str = "[tool]") -> None:
+        self.prefix = prefix
+        self.calls: list[tuple[str, str, str]] = []
+
+    def on_tool_start(
+        self,
+        ctx: RunContextWrapper,
+        tool: Tool,
+        args: str,
+    ) -> None:
+        print(f"{self.prefix} -> {tool.name}({args})")
+
+    def on_tool_end(
+        self,
+        ctx: RunContextWrapper,
+        tool: Tool,
+        result: str,
+    ) -> None:
+        snippet = (result[:120] + "...") if len(result) > 120 else result
+        print(f"{self.prefix} <- {tool.name}: {snippet}")
+        self.calls.append((tool.name, "", snippet))
+
+    def reset(self) -> None:
+        self.calls.clear()
+```
+
+Wire it onto an agent:
+
+```python
+from sinan_agentic_core import AgentDefinition, register_agent
+
+register_agent(AgentDefinition(
+    name="weather_assistant",
+    description="Answers weather questions",
+    instructions="You help users get weather information.",
+    tools=["get_weather"],
+    capabilities=[ToolCallLogger()],
+))
+```
+
+The runner clones `ToolCallLogger()` on every `execute()` call, so each run
+gets its own `calls` list. Inspect the original (template) for aggregate
+state, or read `runner.last_*` if you wired the capability through the kwarg
+path (see below).
+
+### Adding instructions
+
+A capability that contributes to the prompt overrides `instructions`:
+
+```python
+class TimeAwareness(Capability):
+    """Tell the agent the current wall-clock time each turn."""
+
+    def instructions(self, ctx):
+        from datetime import datetime
+        return f"Current time: {datetime.now().isoformat()}"
+```
+
+The runtime joins fragments from every attached capability with double
+newlines and appends them to the agent's base instructions before each LLM
+call. Order matches `AgentDefinition.capabilities`.
+
+### Exposing tools
+
+A capability can hand the agent extra tools by overriding `tools()`. This is
+how `TurnBudget` exposes `request_extension_tool` for self-extension - the
+runner picks them up automatically in `create_agent()`.
+
+### Streaming events
+
+Set `self.on_event` to push a structured event into the stream:
+
+```python
+def on_tool_end(self, ctx, tool, result):
+    if self.on_event:
+        self.on_event({"event": "tool_logged", "data": {"tool": tool.name}})
+```
+
+The runtime wires `on_event` through to clones automatically. Use this for
+UI updates, progress indicators, or any custom telemetry.
+
+## Wiring capabilities
+
+There are two paths into the runner. Pick whichever matches the
+capability's lifetime.
+
+### Declarative (preferred)
+
+Attach to `AgentDefinition.capabilities`. The capability is part of the
+agent's identity; the runner clones it per run for isolation.
+
+```python
+register_agent(AgentDefinition(
+    name="research_agent",
+    description="Deep research",
+    instructions="...",
+    tools=["search", "read"],
+    capabilities=[
+        TurnBudget(default_turns=10),
+        ToolErrorRecovery(),
+        ToolCallLogger(),
+    ],
+))
+```
+
+### Runtime kwargs
+
+For inspection-after-run flows (you want to read `budget.turns_used` after
+`execute()` returns), pass the capability through `execute()`:
+
+```python
+budget = TurnBudget(default_turns=10)
+recovery = ToolErrorRecovery(tool_registry=runner.tool_registry)
+
+await runner.execute(
+    agent_name="research_agent",
+    context=ctx,
+    session=session,
+    input_text="Analyze these papers",
+    turn_budget=budget,
+    error_recovery=recovery,
+)
+
+print(budget.turns_used)
+print(recovery.has_errors)
+```
+
+Runtime kwargs are used in place (not cloned), so post-run state is yours
+to inspect. Declarative capabilities are cloned, so the template stays
+clean across runs.
+
+The runner merges both sources into a single effective list, calls
+`reset()` on each one, then composes them into a single
+`_CompositeHooks` (`base_runner.py:1051-1090`).
+
+## Built-in capabilities
+
+| Capability | What it does |
+|---|---|
+| `TurnBudget` | Soft turn budget with self-extension. Counts turns via `on_llm_start`, injects budget status via `instructions`, exposes `request_extension` via `tools()`. |
+| `ToolErrorRecovery` | Tracks tool errors, detects repeated identical calls, injects progressive recovery guidance via `instructions`. |
+
+Both are first-class `Capability` subclasses. The README sections on
+[Turn Budget](../../README.md#turn-budget-soft-turn-management) and
+[Tool Error Recovery](../../README.md#tool-error-recovery) cover usage.
+
+## Migration notes
+
+**No required changes for direct-Python users.** The `execute()` kwargs
+`turn_budget=` and `error_recovery=` continue to work exactly as before.
+Internally they are now treated as runtime capabilities, but the public
+surface is unchanged - your code keeps running.
+
+**Direct-Python users (recommended path).** New behaviors should land on
+`AgentDefinition.capabilities` so the agent definition is self-contained:
+
+```python
+# Before: behaviors threaded through execute() kwargs only
+await runner.execute(
+    agent_name="agent",
+    context=ctx,
+    session=session,
+    input_text="...",
+    turn_budget=TurnBudget(default_turns=10),
+    error_recovery=ToolErrorRecovery(),
+)
+
+# After (equivalent, declarative): wire on the agent definition
+register_agent(AgentDefinition(
+    name="agent",
+    description="...",
+    instructions="...",
+    tools=[...],
+    capabilities=[
+        TurnBudget(default_turns=10),
+        ToolErrorRecovery(),
+    ],
+))
+
+await runner.execute(
+    agent_name="agent",
+    context=ctx,
+    session=session,
+    input_text="...",
+)
+```
+
+Both forms produce the same effective capability list. Runtime kwargs still
+win when you need to inspect post-run state.
+
+**YAML users.** The current `agents.yaml` schema continues to use the
+`turn_budget:` block and the `error_recovery: bool` flag - those keep
+working as a convenience for the two built-in capabilities. A general
+`capabilities:` YAML block (for arbitrary user-defined capabilities) is the
+next planned increment; until it lands, attach custom capabilities in
+Python after loading the catalog:
+
+```python
+catalog = load_agent_catalog("agents.yaml")
+cfg = catalog.get("research_agent")
+
+register_agent(AgentDefinition(
+    name="research_agent",
+    model=cfg.model,
+    description=cfg.description,
+    tools=cfg.tools,
+    instructions=build_instructions,
+    capabilities=[
+        cfg.build_turn_budget(),
+        cfg.build_error_recovery(),
+        ToolCallLogger(),
+    ],
+))
+```
+
+## Reference
+
+- Protocol: `sinan_agentic_core/core/capabilities/base.py`
+- Composition: `BaseAgentRunner._build_run_capabilities` in
+  `sinan_agentic_core/core/base_runner.py:875`
+- Hook adapter: `_CompositeHooks` in
+  `sinan_agentic_core/core/base_runner.py:1051`
+- Built-ins: `sinan_agentic_core/core/turn_budget.py`,
+  `sinan_agentic_core/core/tool_error_recovery.py`
+- Runnable example: `examples/custom_capability.py`

--- a/examples/custom_capability.py
+++ b/examples/custom_capability.py
@@ -1,0 +1,149 @@
+"""Example: Writing a custom Capability.
+
+A Capability is a pluggable, stateful behavior attached to an agent. The
+runtime invokes its lifecycle hooks at the right moments and merges any
+instruction fragments into the system prompt before each LLM call.
+
+This example defines `ToolCallLogger`, a capability that prints every tool
+call as it happens, and runs an agent end-to-end with the capability
+attached via `AgentDefinition.capabilities`.
+
+Usage:
+    export OPENAI_API_KEY="your-key"
+    python examples/custom_capability.py
+"""
+
+import asyncio
+import os
+from datetime import datetime
+
+from agents import RunContextWrapper, Tool, function_tool
+
+from sinan_agentic_core import (
+    AgentContext,
+    AgentDefinition,
+    AgentSession,
+    BaseAgentRunner,
+    Capability,
+    register_agent,
+    register_tool,
+)
+
+
+# =============================================================================
+# 1. A custom Capability: log every tool call
+# =============================================================================
+
+
+class ToolCallLogger(Capability):
+    """Print every tool call - args in, result out.
+
+    Demonstrates the two most common Capability hooks: `on_tool_start` and
+    `on_tool_end`. Stores the call trace on `self.calls` so callers can
+    inspect it after the run.
+    """
+
+    def __init__(self, prefix: str = "[tool]") -> None:
+        self.prefix = prefix
+        self.calls: list[tuple[str, str]] = []
+
+    def on_tool_start(
+        self,
+        ctx: RunContextWrapper,
+        tool: Tool,
+        args: str,
+    ) -> None:
+        print(f"{self.prefix} -> {tool.name}({args})")
+
+    def on_tool_end(
+        self,
+        ctx: RunContextWrapper,
+        tool: Tool,
+        result: str,
+    ) -> None:
+        snippet = (result[:120] + "...") if len(result) > 120 else result
+        print(f"{self.prefix} <- {tool.name}: {snippet}")
+        self.calls.append((tool.name, snippet))
+
+    def reset(self) -> None:
+        self.calls.clear()
+
+
+# =============================================================================
+# 2. A trivial tool for the agent to call
+# =============================================================================
+
+
+@register_tool(
+    name="get_current_time",
+    description="Get the current date and time",
+    category="utility",
+)
+@function_tool
+async def get_current_time(ctx) -> dict:
+    """Return the current time in ISO format."""
+    return {"current_time": datetime.now().isoformat(), "timezone": "local"}
+
+
+# =============================================================================
+# 3. Register an agent with the capability attached declaratively
+# =============================================================================
+
+
+# Templates declared on the AgentDefinition. The runner calls clone() on
+# each one before every execute() call so concurrent runs stay isolated.
+logger_capability = ToolCallLogger(prefix="[trace]")
+
+register_agent(AgentDefinition(
+    name="time_assistant",
+    description="Tells the user the current time",
+    instructions=(
+        "You are a helpful assistant. When the user asks for the time, "
+        "call the get_current_time tool and report the result."
+    ),
+    tools=["get_current_time"],
+    model="gpt-4o-mini",
+    capabilities=[logger_capability],
+))
+
+
+# =============================================================================
+# 4. Run the agent
+# =============================================================================
+
+
+async def run() -> None:
+    runner = BaseAgentRunner()
+    context = AgentContext()
+    session = AgentSession(session_id="custom-cap-demo")
+
+    print("Asking the agent for the time...\n")
+    output = await runner.execute(
+        agent_name="time_assistant",
+        context=context,
+        session=session,
+        input_text="What time is it right now?",
+    )
+
+    print(f"\nAgent response: {output}")
+
+    # The template is untouched - the runner ran on a clone. Either inspect
+    # the clone via streaming events, or pass a fresh ToolCallLogger as a
+    # runtime kwarg if you need to read its trace after the run.
+    print(f"\nTemplate ToolCallLogger.calls (still empty - clones are isolated):"
+          f" {logger_capability.calls}")
+
+
+async def main() -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("OPENAI_API_KEY not set - skipping live agent run.")
+        print("Export an API key and re-run to see the capability in action:")
+        print("  export OPENAI_API_KEY='your-key'")
+        print("  python examples/custom_capability.py")
+        return
+
+    await run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/yaml_capabilities/agents.yaml
+++ b/examples/yaml_capabilities/agents.yaml
@@ -1,0 +1,20 @@
+agents:
+  scribe:
+    model: gpt-4o-mini
+    description: Demo agent that writes a few words and stops.
+    tools: []
+    max_turns: 8
+
+    # Built-in shorthand keys — resolved into capability factories on load.
+    turn_budget:
+      default_turns: 5
+      reminder_at: 1
+    error_recovery: true
+
+    # Explicit list — references registered capability names. Built-ins
+    # work here too. Custom capabilities (registered via
+    # @register_capability) are referenced exactly like built-ins.
+    capabilities:
+      - name: audit_log
+        config:
+          label: scribe-run

--- a/examples/yaml_capabilities/run.py
+++ b/examples/yaml_capabilities/run.py
@@ -1,0 +1,89 @@
+"""Example: declare capabilities directly in agents.yaml.
+
+This example shows two ways to wire capabilities through YAML:
+
+1. **Shorthand keys** — ``turn_budget`` and ``error_recovery`` are
+   built-in. Set them at the top level of an agent entry.
+2. **Explicit list** — the ``capabilities:`` block references any
+   registered capability by name. Custom capabilities register through
+   ``@register_capability`` and are referenced exactly like built-ins.
+
+Run::
+
+    python examples/yaml_capabilities/run.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agents import RunContextWrapper
+
+from sinan_agentic_core import (
+    AgentDefinition,
+    Capability,
+    load_agent_catalog,
+    register_agent,
+    register_capability,
+)
+
+
+# ---------------------------------------------------------------------------
+# Custom capability — registered under a name that agents.yaml can reference.
+# ---------------------------------------------------------------------------
+
+
+class AuditLog(Capability):
+    """Records every LLM start with the configured label."""
+
+    def __init__(self, label: str = "audit") -> None:
+        self.label = label
+        self.events: list[str] = []
+
+    def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
+        return f"[{self.label}] active"
+
+    def on_llm_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        agent: Any,
+        system_prompt: str | None,
+        input_items: Any,
+    ) -> None:
+        self.events.append(f"llm_start[{self.label}]")
+
+
+@register_capability("audit_log")
+def build_audit_log(config: dict[str, Any]) -> Capability:
+    return AuditLog(**config)
+
+
+# ---------------------------------------------------------------------------
+# Wire YAML -> AgentDefinition.
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    catalog = load_agent_catalog(Path(__file__).parent / "agents.yaml")
+    entry = catalog.get("scribe")
+
+    capabilities = entry.build_capabilities()
+    print(f"Loaded {len(capabilities)} capabilities for 'scribe':")
+    for cap in capabilities:
+        print(f"  - {type(cap).__name__}")
+
+    register_agent(
+        AgentDefinition(
+            name=entry.description.split(".")[0].strip().lower() or "scribe",
+            description=entry.description,
+            instructions="You are a scribe. Write a single sentence and stop.",
+            model=entry.model,
+            tools=[],
+            capabilities=capabilities,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sinan-agentic-core"
-version = "0.7.0"
+version = "0.8.0"
 description = "State-of-the-art framework for building AI agents with OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sinan_agentic_core/__init__.py
+++ b/sinan_agentic_core/__init__.py
@@ -37,7 +37,7 @@ Quick Start:
     )
 """
 
-from .core import BaseAgentRunner, ToolErrorRecovery, ToolErrorRecoveryHooks, TurnBudget, TurnBudgetHooks
+from .core import BaseAgentRunner, Capability, ToolErrorRecovery, TurnBudget
 from .instructions import InstructionBuilder
 from .session import AgentSession, ConversationHistory, SQLiteSessionStore
 from .models.context import AgentContext
@@ -45,6 +45,12 @@ from .models.outputs import ToolOutput, ChatResponse
 from .registry import (
     AgentCatalog,
     AgentYamlEntry,
+    CapabilityFactory,
+    CapabilityNotFoundError,
+    CapabilityRef,
+    CapabilityRegistry,
+    get_capability_registry,
+    register_capability,
     load_agent_catalog,
     AgentDefinition,
     AgentRegistry,
@@ -76,10 +82,9 @@ from .utils import tool_error, tool_response, unwrap_context
 __all__ = [
     # Core
     "BaseAgentRunner",
+    "Capability",
     "ToolErrorRecovery",
-    "ToolErrorRecoveryHooks",
     "TurnBudget",
-    "TurnBudgetHooks",
     # Instructions
     "InstructionBuilder",
     # Session
@@ -93,6 +98,12 @@ __all__ = [
     # Registry
     "AgentCatalog",
     "AgentYamlEntry",
+    "CapabilityFactory",
+    "CapabilityNotFoundError",
+    "CapabilityRef",
+    "CapabilityRegistry",
+    "get_capability_registry",
+    "register_capability",
     "load_agent_catalog",
     "AgentDefinition",
     "AgentRegistry",

--- a/sinan_agentic_core/core/__init__.py
+++ b/sinan_agentic_core/core/__init__.py
@@ -2,22 +2,21 @@
 
 This module contains fundamental components for agent execution:
 - BaseAgentRunner: Abstract base class for all agent runners
-- TurnBudget: Soft turn budget with self-extension
-- TurnBudgetHooks: RunHooks subclass for turn tracking
-- ToolErrorRecovery: Intelligent tool error tracking with progressive guidance
-- ToolErrorRecoveryHooks: RunHooks subclass for tool error tracking
+- Capability: Pluggable agent behavior primitive
+- TurnBudget: Soft turn budget with self-extension (Capability)
+- ToolErrorRecovery: Intelligent tool error tracking (Capability)
 """
 
 from .base_runner import BaseAgentRunner
+from .capabilities import Capability
 from .errors import structured_tool_error
-from .tool_error_recovery import ToolErrorRecovery, ToolErrorRecoveryHooks
-from .turn_budget import TurnBudget, TurnBudgetHooks
+from .tool_error_recovery import ToolErrorRecovery
+from .turn_budget import TurnBudget
 
 __all__ = [
     "BaseAgentRunner",
+    "Capability",
     "structured_tool_error",
     "ToolErrorRecovery",
-    "ToolErrorRecoveryHooks",
     "TurnBudget",
-    "TurnBudgetHooks",
 ]

--- a/sinan_agentic_core/core/base_runner.py
+++ b/sinan_agentic_core/core/base_runner.py
@@ -17,9 +17,10 @@ from ..session import AgentSession
 from ..models.context import AgentContext
 from ..models import outputs as output_models
 from ..registry import get_agent_registry, get_tool_registry, get_guardrail_registry
+from .capabilities import Capability
 from .errors import structured_tool_error
-from .tool_error_recovery import ToolErrorRecovery, ToolErrorRecoveryHooks
-from .turn_budget import TurnBudget, TurnBudgetHooks
+from .tool_error_recovery import ToolErrorRecovery
+from .turn_budget import TurnBudget
 from .turn_budget_tool import request_extension_tool
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,7 @@ class BaseAgentRunner:
         context: Any,
         model_override: Optional[str] = None,
         model_settings_override: Optional["ModelSettings"] = None,
+        capabilities: Optional[List[Capability]] = None,
     ) -> Agent:
         """Create an agent instance with proper tools and configuration.
 
@@ -102,6 +104,8 @@ class BaseAgentRunner:
             context: Context for dynamic instruction generation
             model_override: If set, replaces the agent definition's model.
             model_settings_override: If set, replaces the computed model settings.
+            capabilities: Cloned per-run capabilities to expose tools from.
+                If None, falls back to ``agent_def.capabilities`` (no clone).
 
         Returns:
             Configured Agent instance
@@ -116,6 +120,8 @@ class BaseAgentRunner:
         agent_tools = await self._build_tools(agent_def.tools, context)
         hosted = self._build_hosted_tools(agent_def.hosted_tools)
         agent_tools.extend(hosted)
+        for cap in capabilities or agent_def.capabilities:
+            agent_tools.extend(cap.tools())
         agent_guardrails = self._build_guardrails(agent_def.guardrails)
         handoffs = await self._build_handoffs(agent_def.handoffs, context)
         output_type = self._resolve_output_type(agent_def.output_dataclass)
@@ -172,10 +178,13 @@ class BaseAgentRunner:
     ) -> Any:
         """Run an agent and return its final_output directly.
 
-        Single entry point for all agent execution. Three modes controlled by flags:
-        - Basic (default): Runner.run() -> final_output
-        - Fallback: Runner.run() with overflow recovery -> final_output
-        - Streaming: Runner.run_streamed() with event callbacks -> final_output
+        Capabilities flow through one pipeline. Three sources are merged:
+        1. ``agent_def.capabilities`` (declarative; cloned per run)
+        2. ``turn_budget=`` kwarg (runtime; used in place)
+        3. ``error_recovery=`` kwarg (runtime; used in place)
+
+        All effective capabilities have ``reset()`` called at the start of
+        the run; cloned ones are isolated from their declarative templates.
 
         Args:
             agent_name: Name of registered agent to run
@@ -190,36 +199,42 @@ class BaseAgentRunner:
                 prompt. If None, uses a default builder that concatenates tool outputs.
             max_turns: Maximum agent turns before stopping
             input_text: Input message for the agent (added to session automatically)
-            turn_budget: Optional soft turn budget with self-extension. When provided,
-                the SDK's max_turns is set to budget.absolute_max (hard ceiling) and
-                the agent perceives budget.effective_max (soft limit) via dynamic
-                instructions. The agent can call request_extension() to get more turns.
-            error_recovery: Optional tool error recovery. When provided, tool errors
-                are tracked and progressive recovery guidance is injected into the
-                agent's instructions before each LLM call. Pass True to auto-create
-                with defaults.
+            turn_budget: Optional soft turn budget. Can also be supplied via
+                ``AgentDefinition.capabilities``.
+            error_recovery: Optional tool error recovery. Pass True to auto-create
+                with defaults. Can also be supplied via
+                ``AgentDefinition.capabilities``.
 
         Returns:
             Agent's final_output (dataclass, dict, or string)
         """
-        # When turn budget is active, override max_turns with absolute ceiling
-        sdk_max_turns = turn_budget.absolute_max if turn_budget else max_turns
-
-        if turn_budget:
-            turn_budget.reset()
-            context._turn_budget = turn_budget
+        agent_def = self._get_agent_definition(agent_name)
 
         # Auto-create error recovery if True was passed
         if error_recovery is True:
             error_recovery = ToolErrorRecovery(tool_registry=self.tool_registry)
-        if error_recovery:
-            error_recovery.reset()
+
+        capabilities = self._build_run_capabilities(
+            agent_def=agent_def,
+            turn_budget=turn_budget,
+            error_recovery=error_recovery,
+            on_event=on_event,
+        )
+
+        # Determine SDK max_turns: hardest TurnBudget ceiling wins, else max_turns kwarg.
+        sdk_max_turns = max_turns
+        for cap in capabilities:
+            if isinstance(cap, TurnBudget):
+                sdk_max_turns = cap.absolute_max
+                # Wire the budget so InstructionBuilder.turn_budget_section
+                # and the request_extension tool can locate it.
+                context._turn_budget = cap
+                break
 
         if streaming:
             return await self._execute_streamed(
                 agent_name, context, session, on_event, sdk_max_turns, input_text,
-                turn_budget=turn_budget,
-                error_recovery=error_recovery,
+                capabilities=capabilities,
                 model_override=model_override,
                 model_settings_override=model_settings_override,
             )
@@ -227,14 +242,14 @@ class BaseAgentRunner:
             return await self._execute_with_fallback(
                 agent_name, context, session, sdk_max_turns, input_text,
                 fallback_prompt_builder,
+                capabilities=capabilities,
                 model_override=model_override,
                 model_settings_override=model_settings_override,
             )
         else:
             return await self._execute_basic(
                 agent_name, context, session, sdk_max_turns, input_text,
-                turn_budget=turn_budget,
-                error_recovery=error_recovery,
+                capabilities=capabilities,
                 model_override=model_override,
                 model_settings_override=model_settings_override,
             )
@@ -246,22 +261,20 @@ class BaseAgentRunner:
         session: AgentSession,
         max_turns: int,
         input_text: str,
-        turn_budget: Optional[TurnBudget] = None,
-        error_recovery: Optional[ToolErrorRecovery] = None,
+        capabilities: Optional[List[Capability]] = None,
         model_override: Optional[str] = None,
         model_settings_override: Optional["ModelSettings"] = None,
     ) -> Any:
         """Run agent via Runner.run() and return final_output."""
+        capabilities = capabilities or []
         agent = await self.create_agent(
             agent_name=agent_name, context=context,
             model_override=model_override,
             model_settings_override=model_settings_override,
+            capabilities=capabilities,
         )
 
-        if turn_budget:
-            agent.tools.append(request_extension_tool)
-
-        self._apply_dynamic_instructions(agent, turn_budget, error_recovery)
+        self._apply_dynamic_instructions(agent, capabilities)
 
         logger.info(f"Running agent: {agent_name}")
 
@@ -273,7 +286,7 @@ class BaseAgentRunner:
             "max_turns": max_turns,
         }
 
-        hooks = self._build_hooks(turn_budget, error_recovery)
+        hooks = self._build_hooks(capabilities)
         if hooks:
             run_kwargs["hooks"] = hooks
 
@@ -291,6 +304,7 @@ class BaseAgentRunner:
         max_turns: int,
         input_text: str,
         fallback_prompt_builder: Optional[Callable],
+        capabilities: Optional[List[Capability]] = None,
         model_override: Optional[str] = None,
         model_settings_override: Optional["ModelSettings"] = None,
     ) -> Any:
@@ -299,11 +313,13 @@ class BaseAgentRunner:
         If the agent hits max_turns or context_length_exceeded, collects
         all gathered tool outputs and makes a single condensed LLM call.
         """
+        capabilities = capabilities or []
         agent_def = self._get_agent_definition(agent_name)
         agent = await self.create_agent(
             agent_name=agent_name, context=context,
             model_override=model_override,
             model_settings_override=model_settings_override,
+            capabilities=capabilities,
         )
 
         collecting = _CollectingSessionWrapper(session)
@@ -413,8 +429,7 @@ class BaseAgentRunner:
         on_event: Optional[Callable],
         max_turns: int,
         input_text: str,
-        turn_budget: Optional[TurnBudget] = None,
-        error_recovery: Optional[ToolErrorRecovery] = None,
+        capabilities: Optional[List[Capability]] = None,
         model_override: Optional[str] = None,
         model_settings_override: Optional["ModelSettings"] = None,
     ) -> Any:
@@ -423,16 +438,15 @@ class BaseAgentRunner:
         Adds user message to session, streams events via on_event callback,
         and returns final_output.
         """
+        capabilities = capabilities or []
         agent = await self.create_agent(
             agent_name=agent_name, context=context,
             model_override=model_override,
             model_settings_override=model_settings_override,
+            capabilities=capabilities,
         )
 
-        if turn_budget:
-            agent.tools.append(request_extension_tool)
-
-        self._apply_dynamic_instructions(agent, turn_budget, error_recovery)
+        self._apply_dynamic_instructions(agent, capabilities)
 
         if input_text:
             await session.add_items([{"role": "user", "content": input_text}])
@@ -447,7 +461,7 @@ class BaseAgentRunner:
             "max_turns": max_turns,
         }
 
-        hooks = self._build_hooks(turn_budget, error_recovery, on_event=on_event)
+        hooks = self._build_hooks(capabilities)
         if hooks:
             run_kwargs["hooks"] = hooks
 
@@ -685,9 +699,10 @@ class BaseAgentRunner:
                 budget = agent_def.as_tool_turn_budget
                 if budget:
                     budget.reset()
-                    self._make_instructions_dynamic(tool_agent, budget)
+                    sub_caps: List[Capability] = [budget]
+                    self._apply_dynamic_instructions(tool_agent, sub_caps)
                     tool_agent.tools.append(request_extension_tool)
-                    as_tool_kwargs["hooks"] = TurnBudgetHooks(budget)
+                    as_tool_kwargs["hooks"] = _CompositeHooks(sub_caps)
                     as_tool_kwargs["max_turns"] = budget.absolute_max
                 elif agent_def.as_tool_max_turns is not None:
                     as_tool_kwargs["max_turns"] = agent_def.as_tool_max_turns
@@ -854,24 +869,51 @@ class BaseAgentRunner:
         return agent_kwargs
 
     # ------------------------------------------------------------------ #
-    # Dynamic instructions and hooks composition
+    # Capability composition
     # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _build_run_capabilities(
+        agent_def: Any,
+        turn_budget: Optional[TurnBudget],
+        error_recovery: Optional[ToolErrorRecovery],
+        on_event: Optional[Callable],
+    ) -> List[Capability]:
+        """Compose the effective capability list for one ``execute()`` call.
+
+        Declarative capabilities (``agent_def.capabilities``) are cloned for
+        per-run isolation. Runtime kwargs are used in place so callers can
+        inspect their state after the run. Every effective capability is
+        reset and gets ``on_event`` wired through.
+        """
+        effective: List[Capability] = []
+
+        for cap in agent_def.capabilities:
+            clone = cap.clone()
+            effective.append(clone)
+
+        if turn_budget is not None:
+            effective.append(turn_budget)
+        if error_recovery is not None:
+            effective.append(error_recovery)
+
+        for cap in effective:
+            cap.reset()
+            cap.on_event = on_event
+
+        return effective
 
     @staticmethod
     def _apply_dynamic_instructions(
         agent: Agent,
-        budget: Optional[TurnBudget] = None,
-        recovery: Optional[ToolErrorRecovery] = None,
+        capabilities: List[Capability],
     ) -> None:
-        """Replace static instructions with a callable that appends dynamic sections.
+        """Wrap agent.instructions to merge in capability fragments per turn.
 
         The SDK evaluates callable instructions before each LLM call, so
-        budget and error recovery sections update dynamically.
-
-        Composes all active dynamic sections (turn budget, error recovery)
-        into a single callable.
+        capability sections update dynamically as state evolves.
         """
-        if not budget and not recovery:
+        if not capabilities:
             return
 
         base_instructions = agent.instructions
@@ -881,49 +923,25 @@ class BaseAgentRunner:
 
             def dynamic_instructions(ctx_wrapper, agent_obj):
                 base = original_fn(ctx_wrapper, agent_obj)
-                return _append_dynamic_sections(base, budget, recovery)
+                return _merge_capability_instructions(base, ctx_wrapper, capabilities)
 
             agent.instructions = dynamic_instructions
         else:
             static_text = base_instructions or ""
 
             def dynamic_from_static(ctx_wrapper, agent_obj):
-                return _append_dynamic_sections(static_text, budget, recovery)
+                return _merge_capability_instructions(static_text, ctx_wrapper, capabilities)
 
             agent.instructions = dynamic_from_static
 
     @staticmethod
-    def _make_instructions_dynamic(agent: Agent, budget: TurnBudget) -> None:
-        """Replace static instructions with a callable that appends budget status.
-
-        .. deprecated::
-            Use _apply_dynamic_instructions() for new code. This method is
-            kept for backward compatibility (agent-as-tool budget wiring).
-        """
-        BaseAgentRunner._apply_dynamic_instructions(agent, budget=budget)
-
-    @staticmethod
     def _build_hooks(
-        budget: Optional[TurnBudget] = None,
-        recovery: Optional[ToolErrorRecovery] = None,
-        on_event: Optional[Callable] = None,
+        capabilities: List[Capability],
     ) -> Optional[RunHooks]:
-        """Build a composite RunHooks from active features.
-
-        Returns None if no features are active, a single hooks instance
-        if only one is active, or a _CompositeHooks if multiple are.
-        """
-        hooks_list: list[RunHooks] = []
-        if budget:
-            hooks_list.append(TurnBudgetHooks(budget, on_event=on_event))
-        if recovery:
-            hooks_list.append(ToolErrorRecoveryHooks(recovery, on_event=on_event))
-
-        if not hooks_list:
+        """Wrap capabilities in a single RunHooks adapter, or None when empty."""
+        if not capabilities:
             return None
-        if len(hooks_list) == 1:
-            return hooks_list[0]
-        return _CompositeHooks(hooks_list)
+        return _CompositeHooks(capabilities)
 
     # ------------------------------------------------------------------ #
     # Fallback prompt builder
@@ -1016,58 +1034,57 @@ class _CollectingSessionWrapper:
 # ------------------------------------------------------------------ #
 
 
-def _append_dynamic_sections(
+def _merge_capability_instructions(
     base: str,
-    budget: Optional[TurnBudget],
-    recovery: Optional[ToolErrorRecovery],
+    ctx_wrapper: RunContextWrapper,
+    capabilities: List[Capability],
 ) -> str:
-    """Append active dynamic sections to base instructions."""
+    """Append each capability's current instruction fragment to base."""
     parts = [base]
-    if budget:
-        section = budget.build_instruction_section()
-        if section:
-            parts.append(section)
-    if recovery:
-        section = recovery.build_instruction_section()
-        if section:
-            parts.append(section)
+    for cap in capabilities:
+        fragment = cap.instructions(ctx_wrapper)
+        if fragment:
+            parts.append(fragment)
     return "\n\n".join(parts)
 
 
 class _CompositeHooks(RunHooks):
-    """Compose multiple RunHooks into a single instance.
+    """Adapt a list of capabilities into a single SDK ``RunHooks`` instance.
 
-    The SDK accepts one hooks object per run. This class delegates each
-    lifecycle event to all wrapped hooks in order.
+    Each SDK lifecycle event is dispatched in registration order to every
+    capability's matching method. ``on_tool_start`` extracts ``tool_arguments``
+    from the SDK's ``ToolContext`` so the abstracted Capability signature
+    receives them directly.
     """
 
-    def __init__(self, hooks: List[RunHooks]) -> None:
-        self._hooks = hooks
+    def __init__(self, capabilities: List[Capability]) -> None:
+        self._capabilities = capabilities
 
     async def on_agent_start(self, context, agent):
-        for h in self._hooks:
-            await h.on_agent_start(context, agent)
+        for cap in self._capabilities:
+            cap.on_agent_start(context, agent)
 
     async def on_agent_end(self, context, agent, output):
-        for h in self._hooks:
-            await h.on_agent_end(context, agent, output)
+        for cap in self._capabilities:
+            cap.on_agent_end(context, agent, output)
 
     async def on_handoff(self, context, from_agent, to_agent):
-        for h in self._hooks:
-            await h.on_handoff(context, from_agent, to_agent)
+        for cap in self._capabilities:
+            cap.on_handoff(context, from_agent, to_agent)
 
     async def on_tool_start(self, context, agent, tool):
-        for h in self._hooks:
-            await h.on_tool_start(context, agent, tool)
+        args = getattr(context, "tool_arguments", "")
+        for cap in self._capabilities:
+            cap.on_tool_start(context, tool, args)
 
     async def on_tool_end(self, context, agent, tool, result):
-        for h in self._hooks:
-            await h.on_tool_end(context, agent, tool, result)
+        for cap in self._capabilities:
+            cap.on_tool_end(context, tool, result)
 
     async def on_llm_start(self, context, agent, system_prompt, input_items):
-        for h in self._hooks:
-            await h.on_llm_start(context, agent, system_prompt, input_items)
+        for cap in self._capabilities:
+            cap.on_llm_start(context, agent, system_prompt, input_items)
 
     async def on_llm_end(self, context, agent, response):
-        for h in self._hooks:
-            await h.on_llm_end(context, agent, response)
+        for cap in self._capabilities:
+            cap.on_llm_end(context, agent, response)

--- a/sinan_agentic_core/core/capabilities/__init__.py
+++ b/sinan_agentic_core/core/capabilities/__init__.py
@@ -1,0 +1,5 @@
+"""Capability primitive for pluggable agent behaviors."""
+
+from .base import Capability
+
+__all__ = ["Capability"]

--- a/sinan_agentic_core/core/capabilities/base.py
+++ b/sinan_agentic_core/core/capabilities/base.py
@@ -1,0 +1,163 @@
+"""Capability — pluggable agent behavior primitive.
+
+A ``Capability`` is a single, focused behavior that can be attached to an
+agent (turn budgeting, tool-error recovery, memory, audit logging, ...)
+without editing the runner. The runtime invokes the lifecycle methods at
+the appropriate moments and merges instruction fragments into the system
+prompt before each LLM call.
+
+The shape mirrors OpenAI Agents SDK ``sandbox.Capability`` (clone, bind,
+instructions) so future interop is cheap, but this class does not depend
+on any sandbox internals.
+
+Subclasses override only the methods they need; every method has a safe
+default. Capabilities are stateful and must not leak across runs — the
+runtime calls ``clone()`` before each execution and ``reset()`` at the
+start of each ``execute()`` call.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from typing import Any, Optional
+
+from agents import RunContextWrapper, Tool
+
+
+class Capability:
+    """Base class for pluggable agent behaviors.
+
+    Default implementations are no-ops so that a trivial subclass type-checks
+    under ``mypy --strict`` without overriding anything. Override the methods
+    that matter for the behavior you are adding.
+
+    Lifecycle methods mirror the SDK's ``RunHooks`` shape but with simpler
+    abstracted signatures. The runtime adapter (``_CompositeHooks``) bridges
+    SDK callbacks to these methods.
+
+    Streaming events: assign ``capability.on_event`` to a callback to emit
+    custom events during a run. The runtime sets this on cloned capabilities
+    when streaming.
+    """
+
+    on_event: Optional[Callable[[dict[str, Any]], None]] = None
+
+    def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
+        """Contribute a fragment to the system prompt for the next turn.
+
+        Return ``None`` to contribute nothing. The runtime joins fragments
+        from all attached capabilities and appends them to the agent's
+        base instructions before each LLM call.
+        """
+        return None
+
+    def on_agent_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        agent: Any,
+    ) -> None:
+        """Called when the agent run begins."""
+        return None
+
+    def on_agent_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        agent: Any,
+        output: Any,
+    ) -> None:
+        """Called when the agent run ends with a final output."""
+        return None
+
+    def on_handoff(
+        self,
+        ctx: RunContextWrapper[Any],
+        from_agent: Any,
+        to_agent: Any,
+    ) -> None:
+        """Called when control hands off from one agent to another."""
+        return None
+
+    def on_tool_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        args: str,
+    ) -> None:
+        """Called immediately before a tool executes."""
+        return None
+
+    def on_tool_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        result: str,
+    ) -> None:
+        """Called immediately after a tool executes."""
+        return None
+
+    def on_llm_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        agent: Any,
+        system_prompt: Optional[str],
+        input_items: Any,
+    ) -> None:
+        """Called immediately before the model is invoked for a turn."""
+        return None
+
+    def on_llm_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        agent: Any,
+        response: Any,
+    ) -> None:
+        """Called immediately after the model returns a response."""
+        return None
+
+    def reset(self) -> None:
+        """Reset mutable state. Called at the start of each ``execute()`` call."""
+        return None
+
+    def clone(self) -> Capability:
+        """Return an independent per-run copy.
+
+        The default implementation does a deep copy, which is correct for
+        capabilities whose state is plain Python data. Override when the
+        capability holds non-copyable references (open connections, locks)
+        and needs custom copy semantics.
+        """
+        clone = copy.deepcopy(self)
+        clone.on_event = None
+        return clone
+
+    def to_snapshot(self) -> dict[str, Any] | None:
+        """Return a JSON-serializable snapshot of this capability's mutable state.
+
+        Return ``None`` (the default) to opt out of persistence: the runtime
+        treats the capability as stateless and skips writing a snapshot row.
+        Override to expose counters, queues, or any state that must survive
+        a process restart so the next session can resume mid-run.
+
+        The returned dict must round-trip through ``json.dumps`` /
+        ``json.loads`` — keep values to plain types (str, int, float, bool,
+        list, dict, None).
+        """
+        return None
+
+    def from_snapshot(self, data: dict[str, Any]) -> None:
+        """Rehydrate mutable state from a snapshot produced by ``to_snapshot``.
+
+        The default is a no-op so subclasses without persistence stay
+        unaffected. Implementations should be tolerant of missing keys (the
+        snapshot may have been written by an older version of the
+        capability) and never raise on partial input.
+        """
+        return None
+
+    def tools(self) -> list[Tool]:
+        """Return tools this capability exposes to the agent.
+
+        Reserved for future use. The default returns an empty list.
+        """
+        return []

--- a/sinan_agentic_core/core/tool_error_recovery.py
+++ b/sinan_agentic_core/core/tool_error_recovery.py
@@ -3,33 +3,30 @@
 When a tool returns an error, agents often retry with identical parameters,
 wasting turns in a loop. ToolErrorRecovery solves this by:
 
-1. Tracking tool errors and the arguments that caused them (via RunHooks)
+1. Tracking tool errors and the arguments that caused them (Capability hooks)
 2. Detecting repeated identical calls (same tool + same args)
 3. Injecting progressive recovery guidance into the agent's instructions
-   before each LLM call (via dynamic instructions)
+   before each LLM call (via Capability.instructions)
 
-This follows the same pattern as TurnBudget:
-- State is tracked via RunHooks (on_tool_start / on_tool_end)
-- Guidance is injected via dynamic instructions (callable)
-- The agent reads the guidance and decides what to do (leverages LLM intelligence)
+ToolErrorRecovery is a Capability — wire it via
+``AgentDefinition.capabilities`` or pass to ``execute()`` directly.
 
 Works for all tool types: custom @function_tool, agent-as-tool, and MCP tools.
 
 Usage:
     recovery = ToolErrorRecovery(tool_registry=registry)
-    hooks = ToolErrorRecoveryHooks(recovery)
-    # Compose with other hooks, wire into dynamic instructions
-    # See BaseAgentRunner for integration details.
+    agent_def = AgentDefinition(..., capabilities=[recovery])
 """
 
 import hashlib
 import json
 import logging
-from collections.abc import Callable
-from dataclasses import dataclass, field
-from typing import Any, Optional
+from dataclasses import dataclass
+from typing import Any
 
-from agents import RunHooks
+from agents import RunContextWrapper, Tool
+
+from .capabilities import Capability
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +54,7 @@ class ToolErrorEntry:
     last_args_summary: str = ""
 
 
-class ToolErrorRecovery:
+class ToolErrorRecovery(Capability):
     """Track tool errors and generate recovery guidance for agents.
 
     Detects error patterns (repeated calls, identical arguments) and builds
@@ -90,6 +87,7 @@ class ToolErrorRecovery:
         self._mcp_hints = mcp_hints or {}
         self._errors: dict[str, ToolErrorEntry] = {}  # key: tool_name
         self._last_args: dict[str, str] = {}  # tool_name -> last args_hash
+        self._pending_args: dict[str, str] = {}  # tool_name -> in-flight args
         self.max_identical_before_stop = max_identical_before_stop
 
     # Status values that indicate a tool failure (used by _extract_error).
@@ -103,7 +101,7 @@ class ToolErrorRecovery:
     ) -> None:
         """Record a tool result, tracking errors and clearing on success.
 
-        Called from ToolErrorRecoveryHooks.on_tool_end(). Parses the result
+        Called from on_tool_end(). Parses the result
         to detect errors and tracks:
         - Total error count per tool
         - Identical-argument retry count
@@ -228,6 +226,92 @@ class ToolErrorRecovery:
         """Clear all tracked errors. Called at the start of each execution."""
         self._errors.clear()
         self._last_args.clear()
+        self._pending_args.clear()
+
+    def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
+        """Capability hook — return current recovery guidance, or None when clean."""
+        return self.build_instruction_section() or None
+
+    def on_tool_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        args: str,
+    ) -> None:
+        """Capability hook — capture tool arguments before execution."""
+        tool_name = getattr(tool, "name", str(tool))
+        self._pending_args[tool_name] = args
+
+    def on_tool_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        result: str,
+    ) -> None:
+        """Capability hook — record the tool result and emit any recovery event."""
+        tool_name = getattr(tool, "name", str(tool))
+        arguments = self._pending_args.pop(tool_name, "")
+        self.record_tool_result(tool_name, result, arguments)
+        if self.on_event and self.has_errors:
+            self.on_event({
+                "event": "tool_error_recovery",
+                "data": self.get_error_summary(),
+            })
+
+    def clone(self) -> "ToolErrorRecovery":
+        """Return a fresh ``ToolErrorRecovery`` with the same configuration and zeroed state."""
+        return ToolErrorRecovery(
+            tool_registry=self._registry,
+            mcp_hints=dict(self._mcp_hints),
+            max_identical_before_stop=self.max_identical_before_stop,
+        )
+
+    def to_snapshot(self) -> dict[str, Any]:
+        """Serialize tracked errors and last-args map so retries survive restarts."""
+        return {
+            "errors": {
+                name: {
+                    "tool_name": entry.tool_name,
+                    "error": entry.error,
+                    "args_hash": entry.args_hash,
+                    "call_count": entry.call_count,
+                    "identical_count": entry.identical_count,
+                    "recovery_hint": entry.recovery_hint,
+                    "last_args_summary": entry.last_args_summary,
+                }
+                for name, entry in self._errors.items()
+            },
+            "last_args": dict(self._last_args),
+        }
+
+    def from_snapshot(self, data: dict[str, Any]) -> None:
+        """Restore tracked errors from a previous snapshot.
+
+        ``_pending_args`` is intentionally left empty: it tracks in-flight
+        tool calls that did not survive the process boundary.
+        """
+        raw_errors = data.get("errors", {})
+        self._errors = {}
+        if isinstance(raw_errors, dict):
+            for name, payload in raw_errors.items():
+                if not isinstance(payload, dict):
+                    continue
+                self._errors[str(name)] = ToolErrorEntry(
+                    tool_name=str(payload.get("tool_name", name)),
+                    error=str(payload.get("error", "")),
+                    args_hash=str(payload.get("args_hash", "")),
+                    call_count=int(payload.get("call_count", 1)),
+                    identical_count=int(payload.get("identical_count", 1)),
+                    recovery_hint=str(payload.get("recovery_hint", "")),
+                    last_args_summary=str(payload.get("last_args_summary", "")),
+                )
+        raw_last = data.get("last_args", {})
+        self._last_args = (
+            {str(k): str(v) for k, v in raw_last.items()}
+            if isinstance(raw_last, dict)
+            else {}
+        )
+        self._pending_args = {}
 
     # ------------------------------------------------------------------ #
     # Instruction section builders (progressive escalation)
@@ -330,57 +414,3 @@ class ToolErrorRecovery:
             return arguments[:80]
 
 
-class ToolErrorRecoveryHooks(RunHooks):
-    """RunHooks subclass that tracks tool errors via on_tool_end.
-
-    Captures tool name, arguments, and result after each tool call.
-    The ToolErrorRecovery instance analyzes the result and tracks errors.
-    Dynamic instructions read recovery.build_instruction_section() to
-    inject guidance before the next LLM call.
-
-    Optionally accepts an on_event callback for streaming error events.
-    """
-
-    def __init__(
-        self,
-        recovery: ToolErrorRecovery,
-        on_event: Optional[Callable] = None,
-    ) -> None:
-        self.recovery = recovery
-        self.on_event = on_event
-        self._pending_args: dict[str, str] = {}  # tool_name -> arguments
-
-    async def on_tool_start(
-        self,
-        context: Any,
-        agent: Any,
-        tool: Any,
-    ) -> None:
-        """Capture tool arguments before execution.
-
-        The SDK passes a ToolContext (subclass of RunContextWrapper) that
-        has tool_arguments. We store them here for use in on_tool_end.
-        """
-        tool_name = getattr(tool, "name", str(tool))
-        # ToolContext has .tool_arguments (raw JSON string)
-        arguments = getattr(context, "tool_arguments", "")
-        self._pending_args[tool_name] = arguments
-
-    async def on_tool_end(
-        self,
-        context: Any,
-        agent: Any,
-        tool: Any,
-        result: str,
-    ) -> None:
-        """Record tool result for error tracking."""
-        tool_name = getattr(tool, "name", str(tool))
-        arguments = self._pending_args.pop(tool_name, "")
-
-        self.recovery.record_tool_result(tool_name, result, arguments)
-
-        if self.on_event and self.recovery.has_errors:
-            self.on_event({
-                "event": "tool_error_recovery",
-                "data": self.recovery.get_error_summary(),
-            })

--- a/sinan_agentic_core/core/turn_budget.py
+++ b/sinan_agentic_core/core/turn_budget.py
@@ -6,11 +6,12 @@ Provides a flexible turn budget that agents can self-manage:
 - Agent gets warned when running low on turns
 - Agent can call request_extension() to approve more turns for itself
 
-The TurnBudgetHooks class tracks turns via on_llm_start and injects
-budget awareness into the agent's instructions dynamically.
+TurnBudget is a Capability: the runtime calls ``on_llm_start`` to count
+turns and ``instructions`` to inject budget awareness before each LLM call.
 
 Usage:
     budget = TurnBudget(default_turns=10)
+    # Wire via AgentDefinition.capabilities=[budget] or pass to execute().
     # SDK gets max_turns = budget.absolute_max (hard ceiling)
     # Agent perceives budget.default_turns (soft limit)
     # At turn 8, agent sees "2 turns remaining" in instructions
@@ -19,16 +20,18 @@ Usage:
 
 import logging
 from dataclasses import dataclass, field
-from collections.abc import Callable
 from typing import Any, Optional
 
-from agents import RunHooks
+from agents import RunContextWrapper, Tool
+
+from .capabilities import Capability
+from .turn_budget_tool import request_extension_tool
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
-class TurnBudget:
+class TurnBudget(Capability):
     """Soft turn budget with self-extension capability.
 
     The agent perceives `effective_max` as its budget. The SDK's hard
@@ -154,43 +157,59 @@ class TurnBudget:
         self.extensions_used = 0
         self.extension_reasons.clear()
 
+    def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
+        """Capability hook — return the current budget instruction fragment."""
+        return self.build_instruction_section()
 
-class TurnBudgetHooks(RunHooks):
-    """RunHooks subclass that tracks turns via on_llm_start.
-
-    Each LLM invocation = 1 turn. The hook increments the budget's
-    turn counter before each call. The dynamic instructions callable
-    reads the budget state to inject awareness text.
-
-    Optionally accepts an on_event callback to emit budget status
-    events to the caller (e.g., for streaming to a frontend).
-    """
-
-    def __init__(
+    def on_llm_start(
         self,
-        budget: TurnBudget,
-        on_event: Optional[Callable] = None,
-    ) -> None:
-        self.budget = budget
-        self.on_event = on_event
-
-    async def on_llm_start(
-        self,
-        context: Any,
+        ctx: RunContextWrapper[Any],
         agent: Any,
         system_prompt: Optional[str],
         input_items: Any,
     ) -> None:
-        """Increment turn counter and emit budget event."""
-        self.budget.record_turn()
+        """Capability hook — count this turn and emit a streaming event."""
+        self.record_turn()
         if self.on_event:
             self.on_event({
                 "event": "turn_budget",
                 "data": {
-                    "turns_used": self.budget.turns_used,
-                    "effective_max": self.budget.effective_max,
-                    "remaining": self.budget.remaining,
-                    "extensions_used": self.budget.extensions_used,
-                    "is_warning": self.budget.is_warning,
+                    "turns_used": self.turns_used,
+                    "effective_max": self.effective_max,
+                    "remaining": self.remaining,
+                    "extensions_used": self.extensions_used,
+                    "is_warning": self.is_warning,
                 },
             })
+
+    def tools(self) -> list[Tool]:
+        """Expose request_extension so the agent can self-extend its budget."""
+        return [request_extension_tool]
+
+    def clone(self) -> "TurnBudget":
+        """Return a fresh ``TurnBudget`` with the same configuration and zeroed counters."""
+        return TurnBudget(
+            default_turns=self.default_turns,
+            reminder_at=self.reminder_at,
+            max_extensions=self.max_extensions,
+            extension_size=self.extension_size,
+            absolute_max=self.absolute_max,
+        )
+
+    def to_snapshot(self) -> dict[str, Any]:
+        """Serialize counters so a future session can resume mid-budget."""
+        return {
+            "turns_used": self.turns_used,
+            "extensions_used": self.extensions_used,
+            "extension_reasons": list(self.extension_reasons),
+        }
+
+    def from_snapshot(self, data: dict[str, Any]) -> None:
+        """Restore counters from a previous snapshot.
+
+        Tolerates missing keys so older snapshots stay readable.
+        """
+        self.turns_used = int(data.get("turns_used", 0))
+        self.extensions_used = int(data.get("extensions_used", 0))
+        reasons = data.get("extension_reasons", [])
+        self.extension_reasons = [str(r) for r in reasons] if isinstance(reasons, list) else []

--- a/sinan_agentic_core/registry/__init__.py
+++ b/sinan_agentic_core/registry/__init__.py
@@ -1,9 +1,22 @@
 """Agent and Tool Registry System."""
 
-from .agent_catalog import AgentCatalog, AgentYamlEntry, TurnBudgetConfig, load_agent_catalog
+from .agent_catalog import (
+    AgentCatalog,
+    AgentYamlEntry,
+    CapabilityRef,
+    TurnBudgetConfig,
+    load_agent_catalog,
+)
 from .tool_catalog import ToolCatalog, ToolMCPConfig, ToolYamlEntry, load_tool_catalog
 from .agent_registry import AgentDefinition, AgentRegistry, get_agent_registry, register_agent
 from .agent_factory import create_agent_from_registry
+from .capability_registry import (
+    CapabilityFactory,
+    CapabilityNotFoundError,
+    CapabilityRegistry,
+    get_capability_registry,
+    register_capability,
+)
 from .tool_registry import (
     ToolRegistry,
     get_tool_registry,
@@ -20,6 +33,7 @@ from .guardrail_registry import (
 __all__ = [
     "AgentCatalog",
     "AgentYamlEntry",
+    "CapabilityRef",
     "TurnBudgetConfig",
     "load_agent_catalog",
     "AgentDefinition",
@@ -27,6 +41,11 @@ __all__ = [
     "get_agent_registry",
     "register_agent",
     "create_agent_from_registry",
+    "CapabilityFactory",
+    "CapabilityNotFoundError",
+    "CapabilityRegistry",
+    "get_capability_registry",
+    "register_capability",
     "ToolRegistry",
     "get_tool_registry",
     "register_tool",

--- a/sinan_agentic_core/registry/agent_catalog.py
+++ b/sinan_agentic_core/registry/agent_catalog.py
@@ -34,6 +34,12 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from ..core.capabilities import Capability
+from .capability_registry import (
+    CapabilityNotFoundError,
+    get_capability_registry,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,6 +57,21 @@ class TurnBudgetConfig(BaseModel):
     extension_size: int = 5
 
 
+class CapabilityRef(BaseModel):
+    """Reference to a registered capability with optional config.
+
+    Parsed from the explicit ``capabilities:`` list in ``agents.yaml``::
+
+        capabilities:
+          - name: turn_budget
+            config: { default_turns: 10 }
+          - name: my_custom_capability
+    """
+
+    name: str
+    config: dict[str, Any] = {}
+
+
 class AgentYamlEntry(BaseModel):
     """Resolved agent entry — tools are plain strings."""
 
@@ -61,6 +82,7 @@ class AgentYamlEntry(BaseModel):
     max_turns: int | None = None
     turn_budget: TurnBudgetConfig | None = None
     error_recovery: bool = True
+    capabilities: list[CapabilityRef] = []
     effort: str | None = None
     tool_rules: dict[str, dict[str, Any]] = {}
 
@@ -86,6 +108,30 @@ class AgentYamlEntry(BaseModel):
         from ..registry import get_tool_registry
 
         return ToolErrorRecovery(tool_registry=get_tool_registry())
+
+    def build_capabilities(self) -> list[Capability]:
+        """Build all capabilities for this agent from YAML.
+
+        Combines the built-in shorthand keys (``turn_budget``,
+        ``error_recovery``) with any entries from the explicit
+        ``capabilities:`` list, in that order. The list form goes through
+        :class:`CapabilityRegistry` so user-registered capabilities work
+        identically to built-ins.
+        """
+        built: list[Capability] = []
+
+        budget = self.build_turn_budget()
+        if budget is not None:
+            built.append(budget)
+
+        recovery = self.build_error_recovery()
+        if recovery is not None:
+            built.append(recovery)
+
+        registry = get_capability_registry()
+        for ref in self.capabilities:
+            built.append(registry.build(ref.name, ref.config))
+        return built
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +200,59 @@ def _resolve_tools(
 
 
 # ---------------------------------------------------------------------------
+# Capability resolution
+# ---------------------------------------------------------------------------
+
+
+def _parse_capabilities(
+    agent_name: str, raw: Any
+) -> list[CapabilityRef]:
+    """Parse the ``capabilities:`` list on an agent entry and validate names.
+
+    Accepts the explicit list form documented on :class:`CapabilityRef`.
+    Each entry must be either a string (name only) or a mapping with a
+    ``name`` key and optional ``config`` mapping. Unknown capability names
+    raise :class:`CapabilityNotFoundError`.
+    """
+    if not raw:
+        return []
+    if not isinstance(raw, list):
+        raise TypeError(
+            f"Agent '{agent_name}' has invalid 'capabilities' — "
+            f"expected a list, got {type(raw).__name__}."
+        )
+
+    registry = get_capability_registry()
+    refs: list[CapabilityRef] = []
+    for index, item in enumerate(raw):
+        if isinstance(item, str):
+            ref = CapabilityRef(name=item)
+        elif isinstance(item, dict):
+            if "name" not in item:
+                raise ValueError(
+                    f"Agent '{agent_name}' capabilities[{index}] is missing "
+                    f"the required 'name' key."
+                )
+            ref = CapabilityRef(
+                name=item["name"], config=item.get("config", {}) or {}
+            )
+        else:
+            raise TypeError(
+                f"Agent '{agent_name}' capabilities[{index}] must be a "
+                f"string or mapping, got {type(item).__name__}."
+            )
+
+        if not registry.is_registered(ref.name):
+            available = ", ".join(registry.list_names()) or "<none>"
+            raise CapabilityNotFoundError(
+                f"Agent '{agent_name}' references unknown capability "
+                f"'{ref.name}'. Available: {available}"
+            )
+        refs.append(ref)
+    return refs
+
+
+# ---------------------------------------------------------------------------
 # Catalog
 # ---------------------------------------------------------------------------
 
@@ -200,6 +299,8 @@ class AgentCatalog:
         raw_budget = raw.get("turn_budget")
         budget_cfg = TurnBudgetConfig(**raw_budget) if raw_budget else None
 
+        capabilities = _parse_capabilities(name, raw.get("capabilities", []))
+
         return AgentYamlEntry(
             model=raw["model"],
             description=raw["description"],
@@ -212,6 +313,7 @@ class AgentCatalog:
             max_turns=raw.get("max_turns"),
             turn_budget=budget_cfg,
             error_recovery=raw.get("error_recovery", True),
+            capabilities=capabilities,
             tool_rules=raw.get("tool_rules", {}),
             effort=raw.get("effort"),
         )

--- a/sinan_agentic_core/registry/agent_registry.py
+++ b/sinan_agentic_core/registry/agent_registry.py
@@ -3,13 +3,14 @@
 from dataclasses import dataclass, field
 from typing import List, Callable, Optional, Any, Union
 
+from ..core.capabilities import Capability
+
 
 @dataclass
 class AgentDefinition:
     """Schema for an agent."""
     name: str
     description: str  # Description of agent's purpose
-    #instructions_template: Optional[str] = None  # Static template (deprecated, use instructions)
     instructions: Optional[Union[str, Callable]] = None  # Static string or dynamic function
     # Optional fields (default to empty lists)
     tools: List[str] = field(default_factory=list)         # Tool names from registry
@@ -18,40 +19,35 @@ class AgentDefinition:
     hosted_tools: List[Any] = field(default_factory=list)  # OpenAI SDK hosted tools (WebSearchTool, etc.)
     output_dataclass: Optional[Any] = None  # Dataclass type for structured output
     model_settings_fn: Optional[Callable] = None  # Dynamic model settings function
-    
+    capabilities: List[Capability] = field(default_factory=list)  # Pluggable agent behaviors
+
     model: str = "gpt-4o-mini"
     requires_schema_injection: bool = False  # If True, inject {schema} dynamically
     knowledge_text: str = ""  # Domain knowledge from catalog (injected via domain_knowledge())
     as_tool_parameters: Optional[Any] = None  # Dataclass/Pydantic model for structured agent-as-tool input
     as_tool_max_turns: Optional[int] = None  # Max turns when running as sub-agent via as_tool()
     as_tool_turn_budget: Optional[Any] = None  # TurnBudget instance for sub-agent budget management
-    
+
     def __post_init__(self):
-        """Ensure either instructions_template or instructions is provided."""
-        # Support both old (instructions_template) and new (instructions) patterns
+        """Ensure instructions is provided."""
         if self.instructions is None:
-            raise ValueError(f"Agent {self.name} must have either instructions or instructions_template")
-        
-        # If using new pattern, copy to old field for backward compatibility
-        #if self.instructions is not None:
-        #    if isinstance(self.instructions, str):
-        #        self.instructions_template = self.instructions
+            raise ValueError(f"Agent {self.name} must have instructions")
 
 
 @dataclass
 class AgentRegistry:
     """Central registry of all agents in the system."""
-    
+
     _agents: dict[str, AgentDefinition] = field(default_factory=dict)
-    
+
     def register(self, agent_def: AgentDefinition):
         """Register an agent."""
         self._agents[agent_def.name] = agent_def
-    
+
     def get(self, name: str) -> Optional[AgentDefinition]:
         """Get agent definition by name."""
         return self._agents.get(name)
-    
+
     def list_all(self) -> List[str]:
         """List all registered agent names."""
         return list(self._agents.keys())

--- a/sinan_agentic_core/registry/capability_registry.py
+++ b/sinan_agentic_core/registry/capability_registry.py
@@ -1,0 +1,118 @@
+"""Capability Registry — register and resolve named capability factories.
+
+Mirrors :class:`ToolRegistry` for capabilities. A capability factory is a
+callable that takes a ``config`` dict (parsed from YAML) and returns a
+:class:`Capability` instance.
+
+The two built-in factories — ``turn_budget`` and ``error_recovery`` — are
+registered on import so users can refer to them from ``agents.yaml``
+without writing any Python. Custom capabilities register via the
+:func:`register_capability` decorator::
+
+    from sinan_agentic_core import register_capability, Capability
+
+    @register_capability("audit_log")
+    def build_audit_log(config: dict) -> Capability:
+        return MyAuditCapability(**config)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ..core.capabilities import Capability
+
+CapabilityFactory = Callable[[dict[str, Any]], Capability]
+
+
+class CapabilityNotFoundError(KeyError):
+    """Raised when a YAML capability reference points to an unregistered name."""
+
+
+class CapabilityRegistry:
+    """Central registry mapping capability names to factory callables."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, CapabilityFactory] = {}
+
+    def register(self, name: str, factory: CapabilityFactory) -> None:
+        """Register *factory* under *name*. Re-registration overwrites."""
+        self._factories[name] = factory
+
+    def is_registered(self, name: str) -> bool:
+        return name in self._factories
+
+    def list_names(self) -> list[str]:
+        return sorted(self._factories.keys())
+
+    def get(self, name: str) -> CapabilityFactory:
+        """Return the factory for *name* or raise :class:`CapabilityNotFoundError`."""
+        if name not in self._factories:
+            available = ", ".join(self.list_names()) or "<none>"
+            raise CapabilityNotFoundError(
+                f"Capability '{name}' is not registered. Available: {available}"
+            )
+        return self._factories[name]
+
+    def build(
+        self, name: str, config: dict[str, Any] | None = None
+    ) -> Capability:
+        """Resolve *name* through the registry and invoke its factory."""
+        factory = self.get(name)
+        return factory(dict(config) if config else {})
+
+
+_global_registry = CapabilityRegistry()
+
+
+def get_capability_registry() -> CapabilityRegistry:
+    """Return the process-wide capability registry."""
+    return _global_registry
+
+
+def register_capability(
+    name: str,
+) -> Callable[[CapabilityFactory], CapabilityFactory]:
+    """Decorator: register *factory* under *name* in the global registry.
+
+    Usage::
+
+        @register_capability("audit_log")
+        def build_audit_log(config: dict) -> Capability:
+            return AuditLog(**config)
+    """
+
+    def decorator(factory: CapabilityFactory) -> CapabilityFactory:
+        _global_registry.register(name, factory)
+        return factory
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Built-in capability factories
+# ---------------------------------------------------------------------------
+
+
+@register_capability("turn_budget")
+def _build_turn_budget(config: dict[str, Any]) -> Capability:
+    """Build a :class:`TurnBudget` from YAML config."""
+    from ..core.turn_budget import TurnBudget
+
+    return TurnBudget(**config)
+
+
+@register_capability("error_recovery")
+def _build_error_recovery(config: dict[str, Any]) -> Capability:
+    """Build a :class:`ToolErrorRecovery` from YAML config.
+
+    Defaults ``tool_registry`` to the global registry so YAML users do not
+    need to plumb it through.
+    """
+    from ..core.tool_error_recovery import ToolErrorRecovery
+    from .tool_registry import get_tool_registry
+
+    cfg = dict(config)
+    cfg.setdefault("tool_registry", get_tool_registry())
+    return ToolErrorRecovery(**cfg)

--- a/sinan_agentic_core/session/agent_session.py
+++ b/sinan_agentic_core/session/agent_session.py
@@ -3,10 +3,14 @@
 This is a generic conversation history manager that works with the OpenAI Agents SDK.
 """
 
-from typing import List, Optional, Dict, Any
+from typing import TYPE_CHECKING, Iterable, List, Optional, Dict, Any
 from agents.memory.session import SessionABC
 from agents.items import TResponseInputItem
 import json
+
+if TYPE_CHECKING:
+    from ..core.capabilities import Capability
+    from .sqlite_store import SQLiteSessionStore
 
 
 class ConversationHistory:
@@ -182,12 +186,80 @@ class AgentSession(SessionABC):
     
     def get_metadata(self, key: str, default: Any = None) -> Any:
         """Retrieve session metadata.
-        
+
         Args:
             key: Metadata key
             default: Default value if key not found
-            
+
         Returns:
             Metadata value or default
         """
         return self.metadata.get(key, default)
+
+    # -----------------------------------------------------------------
+    # Capability snapshot/rehydrate
+    # -----------------------------------------------------------------
+
+    def rehydrate_capabilities(
+        self,
+        store: "SQLiteSessionStore",
+        capabilities: Iterable["Capability"],
+    ) -> None:
+        """Restore each capability from its persisted snapshot, if any.
+
+        For every capability that produces a snapshot key (i.e.
+        ``to_snapshot()`` returns a dict), look up the stored blob and call
+        ``from_snapshot()``. Capabilities without a snapshot row are left
+        untouched, and capabilities that opt out of persistence (default
+        ``to_snapshot`` returns ``None``) are silently skipped.
+
+        Args:
+            store: Backing SQLite store that owns the snapshot table.
+            capabilities: Capabilities attached to this session in the
+                same order they will be cloned by the runner.
+        """
+        snapshots = store.load_all_capability_snapshots(self.session_id)
+        if not snapshots:
+            return
+        for capability in capabilities:
+            if capability.to_snapshot() is None:
+                continue
+            key = _capability_key(capability)
+            data = snapshots.get(key)
+            if data is None:
+                continue
+            capability.from_snapshot(data)
+
+    def persist_capabilities(
+        self,
+        store: "SQLiteSessionStore",
+        capabilities: Iterable["Capability"],
+    ) -> None:
+        """Persist a snapshot for each capability that opts in.
+
+        Capabilities whose ``to_snapshot()`` returns ``None`` are treated
+        as stateless and skipped.
+        """
+        for capability in capabilities:
+            data = capability.to_snapshot()
+            if data is None:
+                continue
+            store.save_capability_snapshot(
+                self.session_id,
+                _capability_key(capability),
+                data,
+            )
+
+
+def _capability_key(capability: "Capability") -> str:
+    """Stable identifier for a capability instance.
+
+    Uses the fully-qualified class name so two capabilities of the same
+    type collapse to one snapshot row per session. Subclasses that need
+    per-instance separation can override by setting ``snapshot_key``.
+    """
+    explicit = getattr(capability, "snapshot_key", None)
+    if isinstance(explicit, str) and explicit:
+        return explicit
+    cls = type(capability)
+    return f"{cls.__module__}.{cls.__qualname__}"

--- a/sinan_agentic_core/session/sqlite_store.py
+++ b/sinan_agentic_core/session/sqlite_store.py
@@ -5,6 +5,11 @@ Provides SQLite-backed persistence for chat sessions:
 - Session metadata (created_at, title, archived)
 - Archive old sessions
 - OpenAI-compatible history format
+- Capability snapshots (one JSON blob per capability per session)
+
+Schema migrations are forward-only: each new release adds tables/columns
+without altering existing rows. Older databases pick up new tables on the
+next ``__init__``.
 
 Usage:
     from sinan_agentic_core.session.sqlite_store import SQLiteSessionStore
@@ -95,6 +100,17 @@ class SQLiteSessionStore:
                 ON sessions(is_archived, updated_at)
             """)
 
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS capability_snapshots (
+                    session_id TEXT NOT NULL,
+                    capability_key TEXT NOT NULL,
+                    snapshot TEXT NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (session_id, capability_key),
+                    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+                )
+            """)
+
             conn.commit()
             logger.debug(f"Database initialized at {self.db_path}")
 
@@ -152,6 +168,10 @@ class SQLiteSessionStore:
         with self._connect() as conn:
             cursor = conn.cursor()
             cursor.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            cursor.execute(
+                "DELETE FROM capability_snapshots WHERE session_id = ?",
+                (session_id,),
+            )
             cursor.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
             conn.commit()
             return cursor.rowcount > 0
@@ -284,3 +304,89 @@ class SQLiteSessionStore:
         """
         messages = self.get_messages(session_id)
         return [{"role": m["role"], "content": m["content"]} for m in messages]
+
+    # -----------------------------------------------------------------
+    # Capability snapshots
+    # -----------------------------------------------------------------
+
+    def save_capability_snapshot(
+        self,
+        session_id: str,
+        capability_key: str,
+        snapshot: dict[str, Any],
+    ) -> None:
+        """Persist a capability's snapshot for a session.
+
+        Each ``(session_id, capability_key)`` pair stores at most one row;
+        repeated calls overwrite the previous blob. ``capability_key`` is a
+        stable identifier the caller chooses (typically the capability's
+        class name) — it must match the key used at rehydrate time.
+
+        Args:
+            session_id: Session the snapshot belongs to. The session row is
+                created on demand so callers do not need to seed it first.
+            capability_key: Stable identifier for the capability instance.
+            snapshot: JSON-serializable dict produced by
+                ``Capability.to_snapshot()``.
+        """
+        self.get_or_create_session(session_id)
+        payload = json.dumps(snapshot)
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO capability_snapshots (session_id, capability_key, snapshot)
+                VALUES (?, ?, ?)
+                ON CONFLICT(session_id, capability_key) DO UPDATE SET
+                    snapshot = excluded.snapshot,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (session_id, capability_key, payload),
+            )
+            conn.commit()
+
+    def load_capability_snapshot(
+        self,
+        session_id: str,
+        capability_key: str,
+    ) -> Optional[dict[str, Any]]:
+        """Return the stored snapshot dict, or ``None`` when absent."""
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT snapshot FROM capability_snapshots
+                WHERE session_id = ? AND capability_key = ?
+                """,
+                (session_id, capability_key),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            data = json.loads(row["snapshot"])
+            return data if isinstance(data, dict) else None
+
+    def load_all_capability_snapshots(self, session_id: str) -> dict[str, dict[str, Any]]:
+        """Return every snapshot for a session keyed by capability key."""
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT capability_key, snapshot FROM capability_snapshots WHERE session_id = ?",
+                (session_id,),
+            )
+            result: dict[str, dict[str, Any]] = {}
+            for row in cursor.fetchall():
+                data = json.loads(row["snapshot"])
+                if isinstance(data, dict):
+                    result[row["capability_key"]] = data
+            return result
+
+    def delete_capability_snapshots(self, session_id: str) -> None:
+        """Drop every capability snapshot stored under this session."""
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM capability_snapshots WHERE session_id = ?",
+                (session_id,),
+            )
+            conn.commit()

--- a/tests/core/capabilities/test_base.py
+++ b/tests/core/capabilities/test_base.py
@@ -1,0 +1,166 @@
+"""Tests for the Capability base class (core/capabilities/base.py)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+from agents import RunContextWrapper, Tool
+
+from sinan_agentic_core.core.capabilities import Capability
+
+
+class DummyCapability(Capability):
+    """Trivial subclass used to exercise the default behavior."""
+
+
+class StatefulCapability(Capability):
+    """Capability that tracks calls so we can assert on lifecycle wiring."""
+
+    def __init__(self) -> None:
+        self.counter: int = 0
+        self.tool_starts: list[str] = []
+        self.tool_ends: list[str] = []
+
+    def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
+        return f"counter={self.counter}"
+
+    def on_tool_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        args: str,
+    ) -> None:
+        self.counter += 1
+        self.tool_starts.append(args)
+
+    def on_tool_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        result: str,
+    ) -> None:
+        self.tool_ends.append(result)
+
+    def reset(self) -> None:
+        self.counter = 0
+        self.tool_starts.clear()
+        self.tool_ends.clear()
+
+
+def _ctx() -> RunContextWrapper[Any]:
+    return RunContextWrapper(context=None)
+
+
+class TestImport:
+    def test_capability_is_importable_from_package(self) -> None:
+        from sinan_agentic_core.core.capabilities import Capability as ReExported
+
+        assert ReExported is Capability
+
+
+class TestDefaults:
+    def test_instructions_returns_none(self) -> None:
+        assert DummyCapability().instructions(_ctx()) is None
+
+    def test_on_tool_start_is_noop(self) -> None:
+        cap = DummyCapability()
+        tool = Mock(spec=[], name="dummy_tool")
+        cap.on_tool_start(_ctx(), tool, "{}")  # must not raise
+
+    def test_on_tool_end_is_noop(self) -> None:
+        cap = DummyCapability()
+        tool = Mock(spec=[], name="dummy_tool")
+        cap.on_tool_end(_ctx(), tool, "result")  # must not raise
+
+    def test_reset_is_callable(self) -> None:
+        cap = DummyCapability()
+        cap.reset()  # must not raise
+
+    def test_tools_default_is_empty_list(self) -> None:
+        assert DummyCapability().tools() == []
+
+
+class TestClone:
+    def test_clone_returns_capability_instance(self) -> None:
+        clone = DummyCapability().clone()
+        assert isinstance(clone, Capability)
+
+    def test_clone_returns_independent_instance(self) -> None:
+        original = StatefulCapability()
+        original.counter = 5
+        original.tool_starts.append("a")
+
+        clone = original.clone()
+        assert isinstance(clone, StatefulCapability)
+        assert clone is not original
+        assert clone.counter == 5
+        assert clone.tool_starts == ["a"]
+
+        clone.counter = 99
+        clone.tool_starts.append("b")
+        assert original.counter == 5
+        assert original.tool_starts == ["a"]
+
+    def test_clone_does_not_share_mutable_state(self) -> None:
+        original = StatefulCapability()
+        original.tool_ends.append("x")
+
+        clone = original.clone()
+        assert isinstance(clone, StatefulCapability)
+        assert clone.tool_ends is not original.tool_ends
+
+
+class TestSnapshotDefaults:
+    def test_to_snapshot_defaults_to_none(self) -> None:
+        assert DummyCapability().to_snapshot() is None
+
+    def test_from_snapshot_is_noop(self) -> None:
+        cap = DummyCapability()
+        cap.from_snapshot({"anything": 1})  # must not raise
+
+    def test_subclass_can_override_to_and_from_snapshot(self) -> None:
+        class Persisted(Capability):
+            def __init__(self) -> None:
+                self.value: int = 0
+
+            def to_snapshot(self) -> dict[str, Any]:
+                return {"value": self.value}
+
+            def from_snapshot(self, data: dict[str, Any]) -> None:
+                self.value = int(data.get("value", 0))
+
+        original = Persisted()
+        original.value = 42
+        snap = original.to_snapshot()
+
+        rehydrated = Persisted()
+        assert snap is not None
+        rehydrated.from_snapshot(snap)
+        assert rehydrated.value == 42
+
+
+class TestSubclassLifecycle:
+    def test_subclass_can_override_instructions(self) -> None:
+        cap = StatefulCapability()
+        cap.counter = 7
+        assert cap.instructions(_ctx()) == "counter=7"
+
+    def test_subclass_can_override_tool_hooks(self) -> None:
+        cap = StatefulCapability()
+        tool = Mock(spec=[], name="t")
+        cap.on_tool_start(_ctx(), tool, '{"k":1}')
+        cap.on_tool_end(_ctx(), tool, "ok")
+        assert cap.counter == 1
+        assert cap.tool_starts == ['{"k":1}']
+        assert cap.tool_ends == ["ok"]
+
+    def test_reset_clears_state(self) -> None:
+        cap = StatefulCapability()
+        cap.counter = 3
+        cap.tool_starts.append("x")
+        cap.tool_ends.append("y")
+        cap.reset()
+        assert cap.counter == 0
+        assert cap.tool_starts == []
+        assert cap.tool_ends == []

--- a/tests/test_agent_catalog.py
+++ b/tests/test_agent_catalog.py
@@ -3,19 +3,31 @@
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from agents import RunContextWrapper
 
+from sinan_agentic_core.core.capabilities import Capability
+from sinan_agentic_core.core.tool_error_recovery import ToolErrorRecovery
+from sinan_agentic_core.core.turn_budget import TurnBudget
 from sinan_agentic_core.registry.agent_catalog import (
     AgentCatalog,
     AgentYamlEntry,
+    CapabilityRef,
     TurnBudgetConfig,
     _check_condition,
     _load_knowledge_dir,
+    _parse_capabilities,
     _resolve_dot_path,
     _resolve_knowledge,
     _resolve_tools,
     load_agent_catalog,
+)
+from sinan_agentic_core.registry.capability_registry import (
+    CapabilityNotFoundError,
+    get_capability_registry,
+    register_capability,
 )
 
 
@@ -598,3 +610,276 @@ class TestCatalogTurnBudget:
         assert entry.turn_budget.reminder_at == 2  # default
         assert entry.turn_budget.max_extensions == 3  # default
         assert entry.turn_budget.extension_size == 5  # default
+
+
+# ---------------------------------------------------------------------------
+# Capability YAML parsing
+# ---------------------------------------------------------------------------
+
+
+class _SpyCapability(Capability):
+    """Custom capability used in tests for the explicit list form."""
+
+    def __init__(self, label: str = "spy", level: int = 0) -> None:
+        self.label = label
+        self.level = level
+
+    def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
+        return f"spy({self.label}/{self.level})"
+
+
+@pytest.fixture
+def spy_capability_registered():
+    """Register a spy capability under a unique name for the test, then clean up."""
+    name = "_test_spy_capability"
+
+    @register_capability(name)
+    def factory(config: dict[str, Any]) -> Capability:
+        return _SpyCapability(**config)
+
+    yield name
+    get_capability_registry()._factories.pop(name, None)
+
+
+class TestParseCapabilities:
+    def test_empty_returns_empty(self) -> None:
+        assert _parse_capabilities("a", []) == []
+        assert _parse_capabilities("a", None) == []
+
+    def test_string_form(self) -> None:
+        refs = _parse_capabilities("a", ["turn_budget"])
+        assert refs == [CapabilityRef(name="turn_budget", config={})]
+
+    def test_dict_form_with_config(self) -> None:
+        refs = _parse_capabilities(
+            "a",
+            [{"name": "turn_budget", "config": {"default_turns": 5}}],
+        )
+        assert refs == [
+            CapabilityRef(name="turn_budget", config={"default_turns": 5})
+        ]
+
+    def test_dict_form_without_config(self) -> None:
+        refs = _parse_capabilities("a", [{"name": "error_recovery"}])
+        assert refs == [CapabilityRef(name="error_recovery", config={})]
+
+    def test_dict_form_with_null_config(self) -> None:
+        # YAML may parse a missing value as None — must normalize to {}.
+        refs = _parse_capabilities(
+            "a", [{"name": "turn_budget", "config": None}]
+        )
+        assert refs == [CapabilityRef(name="turn_budget", config={})]
+
+    def test_unknown_name_raises(self) -> None:
+        with pytest.raises(
+            CapabilityNotFoundError, match="unknown capability"
+        ):
+            _parse_capabilities("a", ["does_not_exist"])
+
+    def test_missing_name_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing the required 'name'"):
+            _parse_capabilities("a", [{"config": {}}])
+
+    def test_invalid_item_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="must be a string or mapping"):
+            _parse_capabilities("a", [123])
+
+    def test_non_list_raises(self) -> None:
+        with pytest.raises(TypeError, match="expected a list"):
+            _parse_capabilities("a", {"name": "turn_budget"})
+
+
+class TestCatalogParsesCapabilitiesBlock:
+    def test_string_form_in_yaml(self, tmp_path) -> None:
+        yaml_content = textwrap.dedent("""\
+            agents:
+              chatbot:
+                model: fast
+                description: Test
+                tools: []
+                capabilities:
+                  - turn_budget
+        """)
+        (tmp_path / "agents.yaml").write_text(yaml_content)
+        catalog = load_agent_catalog(tmp_path / "agents.yaml")
+        entry = catalog.get("chatbot")
+        assert entry.capabilities == [
+            CapabilityRef(name="turn_budget", config={})
+        ]
+
+    def test_dict_form_in_yaml(self, tmp_path) -> None:
+        yaml_content = textwrap.dedent("""\
+            agents:
+              chatbot:
+                model: fast
+                description: Test
+                tools: []
+                capabilities:
+                  - name: turn_budget
+                    config:
+                      default_turns: 6
+                      reminder_at: 1
+        """)
+        (tmp_path / "agents.yaml").write_text(yaml_content)
+        catalog = load_agent_catalog(tmp_path / "agents.yaml")
+        entry = catalog.get("chatbot")
+        assert entry.capabilities == [
+            CapabilityRef(
+                name="turn_budget",
+                config={"default_turns": 6, "reminder_at": 1},
+            )
+        ]
+
+    def test_unknown_capability_name_raises_on_get(self, tmp_path) -> None:
+        yaml_content = textwrap.dedent("""\
+            agents:
+              chatbot:
+                model: fast
+                description: Test
+                tools: []
+                capabilities:
+                  - never_registered_capability
+        """)
+        (tmp_path / "agents.yaml").write_text(yaml_content)
+        catalog = load_agent_catalog(tmp_path / "agents.yaml")
+        with pytest.raises(
+            CapabilityNotFoundError, match="never_registered_capability"
+        ):
+            catalog.get("chatbot")
+
+    def test_no_capabilities_block_returns_empty(self, tmp_path) -> None:
+        yaml_content = textwrap.dedent("""\
+            agents:
+              chatbot:
+                model: fast
+                description: Test
+                tools: []
+        """)
+        (tmp_path / "agents.yaml").write_text(yaml_content)
+        catalog = load_agent_catalog(tmp_path / "agents.yaml")
+        entry = catalog.get("chatbot")
+        assert entry.capabilities == []
+
+
+class TestBuildCapabilities:
+    def test_no_capabilities_no_shorthand(self) -> None:
+        entry = AgentYamlEntry(
+            model="fast", description="test", error_recovery=False
+        )
+        assert entry.build_capabilities() == []
+
+    def test_shorthand_only_turn_budget(self) -> None:
+        entry = AgentYamlEntry(
+            model="fast",
+            description="test",
+            max_turns=20,
+            turn_budget=TurnBudgetConfig(default_turns=10),
+            error_recovery=False,
+        )
+        built = entry.build_capabilities()
+        assert len(built) == 1
+        assert isinstance(built[0], TurnBudget)
+        assert built[0].default_turns == 10
+        assert built[0].absolute_max == 20
+
+    def test_shorthand_only_error_recovery(self) -> None:
+        entry = AgentYamlEntry(
+            model="fast", description="test", error_recovery=True
+        )
+        built = entry.build_capabilities()
+        assert len(built) == 1
+        assert isinstance(built[0], ToolErrorRecovery)
+
+    def test_explicit_list_only(self, spy_capability_registered) -> None:
+        entry = AgentYamlEntry(
+            model="fast",
+            description="test",
+            error_recovery=False,
+            capabilities=[
+                CapabilityRef(
+                    name=spy_capability_registered,
+                    config={"label": "x", "level": 2},
+                )
+            ],
+        )
+        built = entry.build_capabilities()
+        assert len(built) == 1
+        assert isinstance(built[0], _SpyCapability)
+        assert built[0].label == "x"
+        assert built[0].level == 2
+
+    def test_mixing_shorthand_and_explicit_list(
+        self, spy_capability_registered
+    ) -> None:
+        entry = AgentYamlEntry(
+            model="fast",
+            description="test",
+            max_turns=15,
+            turn_budget=TurnBudgetConfig(default_turns=8),
+            error_recovery=True,
+            capabilities=[
+                CapabilityRef(
+                    name=spy_capability_registered,
+                    config={"label": "extra"},
+                )
+            ],
+        )
+        built = entry.build_capabilities()
+        # Order: shorthand first (turn_budget, error_recovery), then explicit list.
+        assert [type(c) for c in built] == [
+            TurnBudget,
+            ToolErrorRecovery,
+            _SpyCapability,
+        ]
+        assert built[2].label == "extra"
+
+    def test_explicit_list_built_in_name(self) -> None:
+        entry = AgentYamlEntry(
+            model="fast",
+            description="test",
+            error_recovery=False,
+            capabilities=[
+                CapabilityRef(
+                    name="turn_budget", config={"default_turns": 4}
+                )
+            ],
+        )
+        built = entry.build_capabilities()
+        assert len(built) == 1
+        assert isinstance(built[0], TurnBudget)
+        assert built[0].default_turns == 4
+
+
+class TestCatalogIntegrationWithCapabilities:
+    def test_full_yaml_with_mixed_forms(
+        self, tmp_path, spy_capability_registered
+    ) -> None:
+        yaml_content = textwrap.dedent(f"""\
+            agents:
+              chatbot:
+                model: fast
+                description: Test
+                tools: []
+                max_turns: 30
+                turn_budget:
+                  default_turns: 12
+                error_recovery: true
+                capabilities:
+                  - name: {spy_capability_registered}
+                    config:
+                      label: from_yaml
+                      level: 9
+        """)
+        (tmp_path / "agents.yaml").write_text(yaml_content)
+        catalog = load_agent_catalog(tmp_path / "agents.yaml")
+        entry = catalog.get("chatbot")
+
+        built = entry.build_capabilities()
+        assert [type(c) for c in built] == [
+            TurnBudget,
+            ToolErrorRecovery,
+            _SpyCapability,
+        ]
+        assert built[0].default_turns == 12
+        assert built[2].label == "from_yaml"
+        assert built[2].level == 9

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -1,0 +1,228 @@
+"""Tests for CapabilityRegistry — registration, lookup, factory invocation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agents import RunContextWrapper
+
+from sinan_agentic_core.core.capabilities import Capability
+from sinan_agentic_core.core.tool_error_recovery import ToolErrorRecovery
+from sinan_agentic_core.core.turn_budget import TurnBudget
+from sinan_agentic_core.registry.capability_registry import (
+    CapabilityNotFoundError,
+    CapabilityRegistry,
+    get_capability_registry,
+    register_capability,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test capability
+# ---------------------------------------------------------------------------
+
+
+class _RecorderCapability(Capability):
+    """Trivial capability that just stores the kwargs it was built with."""
+
+    def __init__(self, label: str = "default", flag: bool = False) -> None:
+        self.label = label
+        self.flag = flag
+
+    def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
+        return f"recorder({self.label}, flag={self.flag})"
+
+
+# ---------------------------------------------------------------------------
+# CapabilityRegistry — direct API
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityRegistry:
+    def test_register_and_lookup(self) -> None:
+        reg = CapabilityRegistry()
+
+        def factory(config: dict[str, Any]) -> Capability:
+            return _RecorderCapability(**config)
+
+        reg.register("recorder", factory)
+        assert reg.is_registered("recorder")
+        assert reg.get("recorder") is factory
+        assert "recorder" in reg.list_names()
+
+    def test_unknown_name_raises(self) -> None:
+        reg = CapabilityRegistry()
+        with pytest.raises(CapabilityNotFoundError, match="not registered"):
+            reg.get("missing")
+
+    def test_capability_not_found_is_keyerror(self) -> None:
+        # Caller code that catches KeyError must keep working.
+        assert issubclass(CapabilityNotFoundError, KeyError)
+
+    def test_build_invokes_factory_with_config(self) -> None:
+        reg = CapabilityRegistry()
+        captured: dict[str, Any] = {}
+
+        def factory(config: dict[str, Any]) -> Capability:
+            captured.update(config)
+            return _RecorderCapability(**config)
+
+        reg.register("recorder", factory)
+        cap = reg.build("recorder", {"label": "hi", "flag": True})
+
+        assert isinstance(cap, _RecorderCapability)
+        assert cap.label == "hi"
+        assert cap.flag is True
+        assert captured == {"label": "hi", "flag": True}
+
+    def test_build_with_no_config_passes_empty_dict(self) -> None:
+        reg = CapabilityRegistry()
+        seen: list[dict[str, Any]] = []
+
+        def factory(config: dict[str, Any]) -> Capability:
+            seen.append(config)
+            return _RecorderCapability()
+
+        reg.register("recorder", factory)
+        reg.build("recorder")
+
+        assert seen == [{}]
+
+    def test_build_copies_config_dict(self) -> None:
+        """Mutating the original dict after build must not affect the factory."""
+        reg = CapabilityRegistry()
+
+        def factory(config: dict[str, Any]) -> Capability:
+            return _RecorderCapability(**config)
+
+        reg.register("recorder", factory)
+        config = {"label": "before"}
+        cap = reg.build("recorder", config)
+        config["label"] = "after"
+
+        assert isinstance(cap, _RecorderCapability)
+        assert cap.label == "before"
+
+    def test_re_registration_overwrites(self) -> None:
+        reg = CapabilityRegistry()
+
+        def first(config: dict[str, Any]) -> Capability:
+            return _RecorderCapability(label="first")
+
+        def second(config: dict[str, Any]) -> Capability:
+            return _RecorderCapability(label="second")
+
+        reg.register("x", first)
+        reg.register("x", second)
+
+        cap = reg.build("x")
+        assert isinstance(cap, _RecorderCapability)
+        assert cap.label == "second"
+
+    def test_list_names_sorted(self) -> None:
+        reg = CapabilityRegistry()
+
+        def factory(config: dict[str, Any]) -> Capability:
+            return _RecorderCapability()
+
+        reg.register("zebra", factory)
+        reg.register("alpha", factory)
+        reg.register("middle", factory)
+
+        assert reg.list_names() == ["alpha", "middle", "zebra"]
+
+
+# ---------------------------------------------------------------------------
+# Decorator + global registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterCapabilityDecorator:
+    def test_decorator_registers_in_global(self) -> None:
+        reg = get_capability_registry()
+        name = "test_decorated_cap_unique"
+
+        @register_capability(name)
+        def factory(config: dict[str, Any]) -> Capability:
+            return _RecorderCapability(**config)
+
+        try:
+            assert reg.is_registered(name)
+            cap = reg.build(name, {"label": "via-decorator"})
+            assert isinstance(cap, _RecorderCapability)
+            assert cap.label == "via-decorator"
+        finally:
+            # Don't pollute the global registry across tests.
+            reg._factories.pop(name, None)
+
+    def test_decorator_returns_factory_unchanged(self) -> None:
+        @register_capability("test_returns_unchanged")
+        def factory(config: dict[str, Any]) -> Capability:
+            return _RecorderCapability()
+
+        try:
+            assert callable(factory)
+            assert factory({}).__class__ is _RecorderCapability
+        finally:
+            get_capability_registry()._factories.pop(
+                "test_returns_unchanged", None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Built-in capabilities (registered on import)
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltInCapabilities:
+    def test_turn_budget_registered(self) -> None:
+        reg = get_capability_registry()
+        assert reg.is_registered("turn_budget")
+
+    def test_error_recovery_registered(self) -> None:
+        reg = get_capability_registry()
+        assert reg.is_registered("error_recovery")
+
+    def test_build_turn_budget_with_config(self) -> None:
+        reg = get_capability_registry()
+        cap = reg.build(
+            "turn_budget",
+            {
+                "default_turns": 7,
+                "reminder_at": 1,
+                "max_extensions": 2,
+                "extension_size": 4,
+                "absolute_max": 20,
+            },
+        )
+        assert isinstance(cap, TurnBudget)
+        assert cap.default_turns == 7
+        assert cap.reminder_at == 1
+        assert cap.max_extensions == 2
+        assert cap.extension_size == 4
+        assert cap.absolute_max == 20
+
+    def test_build_turn_budget_defaults(self) -> None:
+        reg = get_capability_registry()
+        cap = reg.build("turn_budget")
+        assert isinstance(cap, TurnBudget)
+        # Sanity-check the dataclass defaults hold.
+        assert cap.default_turns == 10
+
+    def test_build_error_recovery_uses_global_tool_registry(self) -> None:
+        from sinan_agentic_core.registry.tool_registry import (
+            get_tool_registry,
+        )
+
+        reg = get_capability_registry()
+        cap = reg.build("error_recovery")
+        assert isinstance(cap, ToolErrorRecovery)
+        # Defaults to the global tool registry when no override is provided.
+        assert cap._registry is get_tool_registry()
+
+    def test_build_error_recovery_with_explicit_max(self) -> None:
+        reg = get_capability_registry()
+        cap = reg.build("error_recovery", {"max_identical_before_stop": 5})
+        assert isinstance(cap, ToolErrorRecovery)
+        assert cap.max_identical_before_stop == 5

--- a/tests/test_pluggable_capabilities.py
+++ b/tests/test_pluggable_capabilities.py
@@ -1,0 +1,272 @@
+"""Integration tests for ``AgentDefinition.capabilities`` (issue #5).
+
+Verifies the capability pipeline:
+- A custom Capability wired via ``capabilities=[...]`` is dispatched correctly
+  without any ``base_runner.py`` edits.
+- Capability state is isolated across sequential ``execute()`` calls (clones
+  + reset).
+- ``_CompositeHooks`` and ``_apply_dynamic_instructions`` are generic over
+  capabilities (no TurnBudget/ToolErrorRecovery names).
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from agents import RunContextWrapper, Tool
+
+from sinan_agentic_core.core import base_runner as base_runner_module
+from sinan_agentic_core.core.capabilities import Capability
+from sinan_agentic_core.registry.agent_registry import AgentDefinition, AgentRegistry
+from sinan_agentic_core.registry.guardrail_registry import GuardrailRegistry
+from sinan_agentic_core.registry.tool_registry import ToolRegistry
+
+
+class LoggingCapability(Capability):
+    """Records every lifecycle call — used to verify the pipeline."""
+
+    def __init__(self) -> None:
+        self.tool_starts: list[tuple[str, str]] = []
+        self.tool_ends: list[tuple[str, str]] = []
+        self.llm_starts: int = 0
+        self.instruction_calls: int = 0
+
+    def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
+        self.instruction_calls += 1
+        return f"[logging] tool_starts={len(self.tool_starts)}"
+
+    def on_tool_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        args: str,
+    ) -> None:
+        name = getattr(tool, "name", str(tool))
+        self.tool_starts.append((name, args))
+
+    def on_tool_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        result: str,
+    ) -> None:
+        name = getattr(tool, "name", str(tool))
+        self.tool_ends.append((name, result))
+
+    def on_llm_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        agent: Any,
+        system_prompt: str | None,
+        input_items: Any,
+    ) -> None:
+        self.llm_starts += 1
+
+    def reset(self) -> None:
+        self.tool_starts.clear()
+        self.tool_ends.clear()
+        self.llm_starts = 0
+        self.instruction_calls = 0
+
+
+@pytest.fixture
+def runner_with_capability_agent():
+    """Spin up a runner whose registered agent declares a LoggingCapability."""
+    cap = LoggingCapability()
+
+    agent_reg = AgentRegistry()
+    agent_reg.register(
+        AgentDefinition(
+            name="logger_agent",
+            description="agent under test",
+            instructions="You are a test agent.",
+            tools=[],
+            capabilities=[cap],
+        )
+    )
+    tool_reg = ToolRegistry()
+    guardrail_reg = GuardrailRegistry()
+
+    with (
+        patch("sinan_agentic_core.core.base_runner.get_agent_registry", return_value=agent_reg),
+        patch("sinan_agentic_core.core.base_runner.get_tool_registry", return_value=tool_reg),
+        patch("sinan_agentic_core.core.base_runner.get_guardrail_registry", return_value=guardrail_reg),
+    ):
+        from sinan_agentic_core.core.base_runner import BaseAgentRunner
+
+        runner = BaseAgentRunner()
+        yield runner, cap
+
+
+class TestCustomCapabilityIntegration:
+    @pytest.mark.asyncio
+    async def test_capability_lifecycle_dispatches(self, runner_with_capability_agent) -> None:
+        runner, declarative_cap = runner_with_capability_agent
+
+        mock_result = Mock()
+        mock_result.final_output = "ok"
+
+        captured_hooks: dict[str, Any] = {}
+        captured_agent: dict[str, Any] = {}
+
+        async def fake_run(**kwargs):
+            captured_hooks["hooks"] = kwargs.get("hooks")
+            captured_agent["agent"] = kwargs["starting_agent"]
+            return mock_result
+
+        with patch("sinan_agentic_core.core.base_runner.Runner") as MockRunner:
+            MockRunner.run = AsyncMock(side_effect=fake_run)
+            with patch.object(runner, "create_agent", new_callable=AsyncMock) as mock_create:
+                mock_agent = Mock()
+                mock_agent.tools = []
+                mock_agent.instructions = "Static."
+                mock_create.return_value = mock_agent
+
+                await runner.execute(
+                    "logger_agent",
+                    context=Mock(spec=[]),
+                    session=Mock(),
+                    input_text="hello",
+                )
+
+        # The hooks attached to the run dispatch to the *cloned* capability, not
+        # the declarative template instance.
+        composite = captured_hooks["hooks"]
+        assert composite is not None
+        clones = composite._capabilities
+        assert len(clones) == 1
+        run_cap = clones[0]
+        assert isinstance(run_cap, LoggingCapability)
+        assert run_cap is not declarative_cap
+
+        # Drive lifecycle through the SDK-shaped adapter and confirm the clone
+        # received the calls.
+        ctx = Mock()
+        ctx.tool_arguments = '{"q": "hi"}'
+        tool = Mock()
+        tool.name = "search"
+
+        await composite.on_tool_start(ctx, mock_agent, tool)
+        await composite.on_tool_end(ctx, mock_agent, tool, '{"result":"x"}')
+        await composite.on_llm_start(ctx, mock_agent, None, [])
+
+        assert run_cap.tool_starts == [("search", '{"q": "hi"}')]
+        assert run_cap.tool_ends == [("search", '{"result":"x"}')]
+        assert run_cap.llm_starts == 1
+
+        # Declarative template stays clean.
+        assert declarative_cap.tool_starts == []
+        assert declarative_cap.tool_ends == []
+        assert declarative_cap.llm_starts == 0
+
+    @pytest.mark.asyncio
+    async def test_capability_instructions_are_merged(self, runner_with_capability_agent) -> None:
+        runner, _ = runner_with_capability_agent
+
+        mock_result = Mock()
+        mock_result.final_output = "ok"
+
+        captured: dict[str, Any] = {}
+
+        async def fake_run(**kwargs):
+            captured["agent"] = kwargs["starting_agent"]
+            return mock_result
+
+        with patch("sinan_agentic_core.core.base_runner.Runner") as MockRunner:
+            MockRunner.run = AsyncMock(side_effect=fake_run)
+            with patch.object(runner, "create_agent", new_callable=AsyncMock) as mock_create:
+                mock_agent = Mock()
+                mock_agent.tools = []
+                mock_agent.instructions = "Base instructions."
+                mock_create.return_value = mock_agent
+
+                await runner.execute(
+                    "logger_agent",
+                    context=Mock(spec=[]),
+                    session=Mock(),
+                    input_text="hello",
+                )
+
+        # ``_apply_dynamic_instructions`` wraps the agent's instructions with a
+        # callable that merges every capability fragment.
+        wrapped = captured["agent"].instructions
+        assert callable(wrapped)
+        rendered = wrapped(RunContextWrapper(context=None), captured["agent"])
+        assert "Base instructions." in rendered
+        assert "[logging]" in rendered
+
+
+class TestCapabilityStateIsolation:
+    @pytest.mark.asyncio
+    async def test_state_does_not_leak_between_runs(self, runner_with_capability_agent) -> None:
+        runner, declarative_cap = runner_with_capability_agent
+
+        mock_result = Mock()
+        mock_result.final_output = "ok"
+
+        captured_clones: list[LoggingCapability] = []
+
+        async def fake_run(**kwargs):
+            composite = kwargs["hooks"]
+            run_cap = composite._capabilities[0]
+            assert isinstance(run_cap, LoggingCapability)
+            captured_clones.append(run_cap)
+            # Simulate work during the run: bump state.
+            run_cap.tool_starts.append(("simulated", "{}"))
+            run_cap.llm_starts += 1
+            return mock_result
+
+        with patch("sinan_agentic_core.core.base_runner.Runner") as MockRunner:
+            MockRunner.run = AsyncMock(side_effect=fake_run)
+            with patch.object(runner, "create_agent", new_callable=AsyncMock) as mock_create:
+                mock_agent = Mock()
+                mock_agent.tools = []
+                mock_agent.instructions = "Static."
+                mock_create.return_value = mock_agent
+
+                # Two sequential runs share the same registered AgentDefinition
+                # — yet state must not bleed across them.
+                await runner.execute(
+                    "logger_agent",
+                    context=Mock(spec=[]),
+                    session=Mock(),
+                    input_text="hello",
+                )
+                await runner.execute(
+                    "logger_agent",
+                    context=Mock(spec=[]),
+                    session=Mock(),
+                    input_text="world",
+                )
+
+        assert len(captured_clones) == 2
+        run1, run2 = captured_clones
+        # Each run got its own clone — verifies clone() wired through.
+        assert run1 is not run2
+        assert run1 is not declarative_cap
+        assert run2 is not declarative_cap
+        # Run-1's mutations did not leak into run-2 — verifies reset() at the
+        # start of the second execute().
+        assert run2.tool_starts == [("simulated", "{}")]
+        assert run2.llm_starts == 1
+        # The declarative template stays pristine across both runs.
+        assert declarative_cap.tool_starts == []
+        assert declarative_cap.llm_starts == 0
+
+
+class TestCompositeHooksGeneric:
+    """Verify ``_CompositeHooks`` and the dynamic-instructions builder no
+    longer reference TurnBudget or ToolErrorRecovery by name."""
+
+    def test_composite_hooks_source_has_no_turn_budget_branch(self) -> None:
+        src = inspect.getsource(base_runner_module._CompositeHooks)
+        assert "TurnBudget" not in src
+        assert "ToolErrorRecovery" not in src
+
+    def test_dynamic_instructions_helper_has_no_capability_branches(self) -> None:
+        src = inspect.getsource(base_runner_module._merge_capability_instructions)
+        assert "TurnBudget" not in src
+        assert "ToolErrorRecovery" not in src

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -18,7 +18,7 @@ class TestAgentDefinition:
         assert a.tools == []
 
     def test_missing_instructions_raises(self):
-        with pytest.raises(ValueError, match="must have either instructions"):
+        with pytest.raises(ValueError, match="must have instructions"):
             AgentDefinition(name="bad", description="d")
 
     def test_callable_instructions(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from sinan_agentic_core.core.capabilities import Capability
+from sinan_agentic_core.core.tool_error_recovery import ToolErrorRecovery
+from sinan_agentic_core.core.turn_budget import TurnBudget
 from sinan_agentic_core.session.agent_session import AgentSession, ConversationHistory
 from sinan_agentic_core.session.sqlite_store import SQLiteSessionStore
 
@@ -190,3 +193,149 @@ class TestSQLiteSessionStore:
         store.add_message("s1", "user", "msg", metadata={"source": "web"})
         messages = store.get_messages("s1")
         assert messages[0]["metadata"] == {"source": "web"}
+
+
+# -- Capability snapshot persistence ------------------------------------------
+
+
+class _NoopRecorder(Capability):
+    """Stateless capability — to_snapshot returns None by default."""
+
+
+class _ManualSnapshot(Capability):
+    """Capability that opts in to persistence with a custom snapshot key."""
+
+    snapshot_key = "manual.snapshot"
+
+    def __init__(self) -> None:
+        self.tally: int = 0
+
+    def to_snapshot(self):
+        return {"tally": self.tally}
+
+    def from_snapshot(self, data):
+        self.tally = int(data.get("tally", 0))
+
+
+class TestSQLiteCapabilitySnapshots:
+    @pytest.fixture
+    def store(self, tmp_path):
+        return SQLiteSessionStore(str(tmp_path / "snap.db"))
+
+    def test_save_and_load_snapshot(self, store):
+        store.save_capability_snapshot("s1", "TurnBudget", {"turns_used": 4})
+        assert store.load_capability_snapshot("s1", "TurnBudget") == {"turns_used": 4}
+
+    def test_load_missing_snapshot_returns_none(self, store):
+        assert store.load_capability_snapshot("s1", "TurnBudget") is None
+
+    def test_save_overwrites_existing_snapshot(self, store):
+        store.save_capability_snapshot("s1", "TurnBudget", {"turns_used": 1})
+        store.save_capability_snapshot("s1", "TurnBudget", {"turns_used": 7})
+        assert store.load_capability_snapshot("s1", "TurnBudget") == {"turns_used": 7}
+
+    def test_snapshots_are_scoped_per_session(self, store):
+        store.save_capability_snapshot("s1", "TurnBudget", {"turns_used": 1})
+        store.save_capability_snapshot("s2", "TurnBudget", {"turns_used": 9})
+        assert store.load_capability_snapshot("s1", "TurnBudget") == {"turns_used": 1}
+        assert store.load_capability_snapshot("s2", "TurnBudget") == {"turns_used": 9}
+
+    def test_load_all_snapshots_returns_keyed_dict(self, store):
+        store.save_capability_snapshot("s1", "TurnBudget", {"turns_used": 4})
+        store.save_capability_snapshot("s1", "ToolErrorRecovery", {"errors": {}})
+        snapshots = store.load_all_capability_snapshots("s1")
+        assert snapshots == {
+            "TurnBudget": {"turns_used": 4},
+            "ToolErrorRecovery": {"errors": {}},
+        }
+
+    def test_clear_session_drops_snapshots(self, store):
+        store.save_capability_snapshot("s1", "TurnBudget", {"turns_used": 4})
+        store.clear_session("s1")
+        assert store.load_capability_snapshot("s1", "TurnBudget") is None
+
+    def test_delete_capability_snapshots(self, store):
+        store.save_capability_snapshot("s1", "TurnBudget", {"turns_used": 4})
+        store.delete_capability_snapshots("s1")
+        assert store.load_all_capability_snapshots("s1") == {}
+
+
+class TestAgentSessionRehydrate:
+    @pytest.fixture
+    def store(self, tmp_path):
+        return SQLiteSessionStore(str(tmp_path / "hydrate.db"))
+
+    def test_turn_budget_round_trip_through_session_and_store(self, store):
+        # AC: configure a TurnBudget to 10 turns, advance counter to 4, snapshot,
+        #     rehydrate in a new session, confirm 6 turns remain.
+        original_budget = TurnBudget(default_turns=10)
+        for _ in range(4):
+            original_budget.record_turn()
+
+        original_session = AgentSession(session_id="resume-1")
+        original_session.persist_capabilities(store, [original_budget])
+
+        resumed_budget = TurnBudget(default_turns=10)
+        resumed_session = AgentSession(session_id="resume-1")
+        resumed_session.rehydrate_capabilities(store, [resumed_budget])
+
+        assert resumed_budget.turns_used == 4
+        assert resumed_budget.remaining == 6
+
+    def test_tool_error_recovery_round_trip(self, store):
+        from unittest.mock import Mock
+
+        from agents import RunContextWrapper
+
+        original = ToolErrorRecovery()
+        ctx = RunContextWrapper(context=None)
+        tool = Mock()
+        tool.name = "search"
+        import json as _json
+        original.on_tool_start(ctx, tool, _json.dumps({"q": "x"}))
+        original.on_tool_end(ctx, tool, _json.dumps({"error": "boom"}))
+
+        AgentSession(session_id="resume-2").persist_capabilities(store, [original])
+
+        resumed = ToolErrorRecovery()
+        AgentSession(session_id="resume-2").rehydrate_capabilities(store, [resumed])
+
+        assert resumed.has_errors
+        assert resumed._errors["search"].error == "boom"
+
+    def test_stateless_capability_is_skipped(self, store):
+        # Stateless capability (default to_snapshot returns None) must not crash
+        # and must not write any row.
+        cap = _NoopRecorder()
+        session = AgentSession(session_id="resume-3")
+        session.persist_capabilities(store, [cap])
+        assert store.load_all_capability_snapshots("resume-3") == {}
+
+        # Rehydrating with no row stored is also a no-op.
+        session.rehydrate_capabilities(store, [cap])  # must not raise
+
+    def test_rehydrate_skips_capabilities_without_stored_row(self, store):
+        # If only one capability has a stored snapshot, the others stay
+        # untouched at their zeroed defaults.
+        budget = TurnBudget(default_turns=10)
+        budget.record_turn()
+        AgentSession(session_id="mixed").persist_capabilities(store, [budget])
+
+        resumed_budget = TurnBudget(default_turns=10)
+        resumed_recovery = ToolErrorRecovery()
+        AgentSession(session_id="mixed").rehydrate_capabilities(
+            store, [resumed_budget, resumed_recovery]
+        )
+        assert resumed_budget.turns_used == 1
+        assert not resumed_recovery.has_errors
+
+    def test_explicit_snapshot_key_is_honored(self, store):
+        cap = _ManualSnapshot()
+        cap.tally = 12
+        AgentSession(session_id="manual").persist_capabilities(store, [cap])
+        snapshots = store.load_all_capability_snapshots("manual")
+        assert "manual.snapshot" in snapshots
+
+        resumed = _ManualSnapshot()
+        AgentSession(session_id="manual").rehydrate_capabilities(store, [resumed])
+        assert resumed.tally == 12

--- a/tests/test_tool_error_recovery.py
+++ b/tests/test_tool_error_recovery.py
@@ -4,11 +4,12 @@ import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from agents import RunContextWrapper
 
+from sinan_agentic_core.core.capabilities import Capability
 from sinan_agentic_core.core.tool_error_recovery import (
     ToolErrorEntry,
     ToolErrorRecovery,
-    ToolErrorRecoveryHooks,
 )
 
 
@@ -324,81 +325,66 @@ class TestArgsHashing:
 
 
 # ------------------------------------------------------------------ #
-# ToolErrorRecoveryHooks
+# ToolErrorRecovery — capability lifecycle hooks
 # ------------------------------------------------------------------ #
 
 
-class TestToolErrorRecoveryHooks:
-    @pytest.mark.asyncio
-    async def test_on_tool_end_records_result(self):
+class TestToolErrorRecoveryLifecycle:
+    def test_on_tool_end_records_result(self):
         recovery = ToolErrorRecovery()
-        hooks = ToolErrorRecoveryHooks(recovery)
 
         tool = Mock()
         tool.name = "my_tool"
 
-        # Simulate on_tool_start to capture args
         ctx = Mock()
-        ctx.tool_arguments = json.dumps({"mode": "check"})
-        await hooks.on_tool_start(ctx, Mock(), tool)
-
-        # Simulate on_tool_end with error
-        await hooks.on_tool_end(ctx, Mock(), tool, json.dumps({"error": "fail"}))
+        recovery.on_tool_start(ctx, tool, json.dumps({"mode": "check"}))
+        recovery.on_tool_end(ctx, tool, json.dumps({"error": "fail"}))
 
         assert recovery.has_errors
         summary = recovery.get_error_summary()
         assert summary["my_tool"]["error"] == "fail"
 
-    @pytest.mark.asyncio
-    async def test_on_tool_end_success_clears_error(self):
+    def test_on_tool_end_success_clears_error(self):
         recovery = ToolErrorRecovery()
-        hooks = ToolErrorRecoveryHooks(recovery)
 
         tool = Mock()
         tool.name = "my_tool"
         ctx = Mock()
-        ctx.tool_arguments = "{}"
 
-        # Error first
-        await hooks.on_tool_start(ctx, Mock(), tool)
-        await hooks.on_tool_end(ctx, Mock(), tool, json.dumps({"error": "fail"}))
+        recovery.on_tool_start(ctx, tool, "{}")
+        recovery.on_tool_end(ctx, tool, json.dumps({"error": "fail"}))
         assert recovery.has_errors
 
-        # Then success
-        await hooks.on_tool_start(ctx, Mock(), tool)
-        await hooks.on_tool_end(ctx, Mock(), tool, json.dumps({"result": "ok"}))
+        recovery.on_tool_start(ctx, tool, "{}")
+        recovery.on_tool_end(ctx, tool, json.dumps({"result": "ok"}))
         assert not recovery.has_errors
 
-    @pytest.mark.asyncio
-    async def test_on_event_emitted_on_error(self):
+    def test_on_event_emitted_on_error(self):
         recovery = ToolErrorRecovery()
-        events = []
-        hooks = ToolErrorRecoveryHooks(recovery, on_event=events.append)
+        events: list[dict] = []
+        recovery.on_event = events.append
 
         tool = Mock()
         tool.name = "my_tool"
         ctx = Mock()
-        ctx.tool_arguments = "{}"
 
-        await hooks.on_tool_start(ctx, Mock(), tool)
-        await hooks.on_tool_end(ctx, Mock(), tool, json.dumps({"error": "fail"}))
+        recovery.on_tool_start(ctx, tool, "{}")
+        recovery.on_tool_end(ctx, tool, json.dumps({"error": "fail"}))
 
         assert len(events) == 1
         assert events[0]["event"] == "tool_error_recovery"
 
-    @pytest.mark.asyncio
-    async def test_no_event_on_success(self):
+    def test_no_event_on_success(self):
         recovery = ToolErrorRecovery()
-        events = []
-        hooks = ToolErrorRecoveryHooks(recovery, on_event=events.append)
+        events: list[dict] = []
+        recovery.on_event = events.append
 
         tool = Mock()
         tool.name = "my_tool"
         ctx = Mock()
-        ctx.tool_arguments = "{}"
 
-        await hooks.on_tool_start(ctx, Mock(), tool)
-        await hooks.on_tool_end(ctx, Mock(), tool, json.dumps({"data": "ok"}))
+        recovery.on_tool_start(ctx, tool, "{}")
+        recovery.on_tool_end(ctx, tool, json.dumps({"data": "ok"}))
 
         assert len(events) == 0
 
@@ -447,17 +433,17 @@ class TestBaseAgentRunnerIntegration:
 
         agent = Mock()
         agent.instructions = "Base instructions."
-        runner._apply_dynamic_instructions(agent, recovery=recovery)
+        runner._apply_dynamic_instructions(agent, [recovery])
 
         assert callable(agent.instructions)
         result = agent.instructions(Mock(), Mock())
         assert "Base instructions." in result
         assert "Tool Error Recovery" in result
 
-    def test_apply_dynamic_instructions_no_features(self, runner):
+    def test_apply_dynamic_instructions_no_capabilities(self, runner):
         agent = Mock()
         agent.instructions = "Static."
-        runner._apply_dynamic_instructions(agent)
+        runner._apply_dynamic_instructions(agent, [])
         # Should NOT replace with callable
         assert agent.instructions == "Static."
 
@@ -471,41 +457,35 @@ class TestBaseAgentRunnerIntegration:
 
         agent = Mock()
         agent.instructions = "Base."
-        runner._apply_dynamic_instructions(agent, budget=budget, recovery=recovery)
+        runner._apply_dynamic_instructions(agent, [budget, recovery])
 
         result = agent.instructions(Mock(), Mock())
         assert "Base." in result
         assert "remaining" in result  # budget section
         assert "Tool Error Recovery" in result  # recovery section
 
-    def test_build_hooks_none_when_no_features(self):
+    def test_build_hooks_none_when_no_capabilities(self):
         from sinan_agentic_core.core.base_runner import BaseAgentRunner
-        assert BaseAgentRunner._build_hooks() is None
+        assert BaseAgentRunner._build_hooks([]) is None
 
-    def test_build_hooks_single_budget(self):
-        from sinan_agentic_core.core.base_runner import BaseAgentRunner
-        from sinan_agentic_core.core.turn_budget import TurnBudget, TurnBudgetHooks
-
-        hooks = BaseAgentRunner._build_hooks(budget=TurnBudget())
-        assert isinstance(hooks, TurnBudgetHooks)
-
-    def test_build_hooks_single_recovery(self):
-        from sinan_agentic_core.core.base_runner import BaseAgentRunner
-
-        hooks = BaseAgentRunner._build_hooks(recovery=ToolErrorRecovery())
-        assert isinstance(hooks, ToolErrorRecoveryHooks)
-
-    def test_build_hooks_composite_when_both(self):
+    def test_build_hooks_returns_composite(self):
         from sinan_agentic_core.core.base_runner import BaseAgentRunner, _CompositeHooks
         from sinan_agentic_core.core.turn_budget import TurnBudget
 
-        hooks = BaseAgentRunner._build_hooks(
-            budget=TurnBudget(), recovery=ToolErrorRecovery()
-        )
+        hooks = BaseAgentRunner._build_hooks([TurnBudget()])
+        assert isinstance(hooks, _CompositeHooks)
+
+    def test_build_hooks_composite_when_multiple(self):
+        from sinan_agentic_core.core.base_runner import BaseAgentRunner, _CompositeHooks
+        from sinan_agentic_core.core.turn_budget import TurnBudget
+
+        hooks = BaseAgentRunner._build_hooks([TurnBudget(), ToolErrorRecovery()])
         assert isinstance(hooks, _CompositeHooks)
 
     @pytest.mark.asyncio
     async def test_execute_basic_with_recovery(self, runner):
+        from sinan_agentic_core.core.base_runner import _CompositeHooks
+
         recovery = ToolErrorRecovery()
         context = Mock()
         session = Mock()
@@ -523,12 +503,12 @@ class TestBaseAgentRunnerIntegration:
 
                 result = await runner._execute_basic(
                     "test_agent", context, session, 10, "hello",
-                    error_recovery=recovery,
+                    capabilities=[recovery],
                 )
 
                 assert result == "test output"
                 call_kwargs = MockRunner.run.call_args[1]
-                assert isinstance(call_kwargs["hooks"], ToolErrorRecoveryHooks)
+                assert isinstance(call_kwargs["hooks"], _CompositeHooks)
 
     @pytest.mark.asyncio
     async def test_execute_resets_recovery(self, runner):
@@ -554,30 +534,36 @@ class TestBaseAgentRunnerIntegration:
 
 class TestCompositeHooks:
     @pytest.mark.asyncio
-    async def test_delegates_to_all_hooks(self):
+    async def test_delegates_to_all_capabilities(self):
         from sinan_agentic_core.core.base_runner import _CompositeHooks
 
-        hook_a = Mock()
-        hook_a.on_tool_start = AsyncMock()
-        hook_a.on_tool_end = AsyncMock()
-        hook_a.on_llm_start = AsyncMock()
+        cap_a = Mock(spec=Capability)
+        cap_b = Mock(spec=Capability)
 
-        hook_b = Mock()
-        hook_b.on_tool_start = AsyncMock()
-        hook_b.on_tool_end = AsyncMock()
-        hook_b.on_llm_start = AsyncMock()
-
-        composite = _CompositeHooks([hook_a, hook_b])
+        composite = _CompositeHooks([cap_a, cap_b])
         await composite.on_tool_start(Mock(), Mock(), Mock())
         await composite.on_tool_end(Mock(), Mock(), Mock(), "result")
         await composite.on_llm_start(Mock(), Mock(), None, [])
 
-        hook_a.on_tool_start.assert_called_once()
-        hook_b.on_tool_start.assert_called_once()
-        hook_a.on_tool_end.assert_called_once()
-        hook_b.on_tool_end.assert_called_once()
-        hook_a.on_llm_start.assert_called_once()
-        hook_b.on_llm_start.assert_called_once()
+        cap_a.on_tool_start.assert_called_once()
+        cap_b.on_tool_start.assert_called_once()
+        cap_a.on_tool_end.assert_called_once()
+        cap_b.on_tool_end.assert_called_once()
+        cap_a.on_llm_start.assert_called_once()
+        cap_b.on_llm_start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_extracts_tool_arguments_from_context(self):
+        from sinan_agentic_core.core.base_runner import _CompositeHooks
+
+        cap = Mock(spec=Capability)
+        composite = _CompositeHooks([cap])
+        ctx = Mock()
+        ctx.tool_arguments = json.dumps({"x": 1})
+        tool = Mock()
+
+        await composite.on_tool_start(ctx, Mock(), tool)
+        cap.on_tool_start.assert_called_once_with(ctx, tool, ctx.tool_arguments)
 
 
 # ------------------------------------------------------------------ #
@@ -587,11 +573,205 @@ class TestCompositeHooks:
 
 class TestTopLevelImports:
     def test_importable_from_core(self):
-        from sinan_agentic_core.core import ToolErrorRecovery, ToolErrorRecoveryHooks
+        from sinan_agentic_core.core import ToolErrorRecovery
         assert ToolErrorRecovery is not None
-        assert ToolErrorRecoveryHooks is not None
 
     def test_importable_from_top_level(self):
-        from sinan_agentic_core import ToolErrorRecovery, ToolErrorRecoveryHooks
+        from sinan_agentic_core import ToolErrorRecovery
         assert ToolErrorRecovery is not None
-        assert ToolErrorRecoveryHooks is not None
+
+
+# ------------------------------------------------------------------ #
+# Capability protocol adoption
+# ------------------------------------------------------------------ #
+
+
+class TestToolErrorRecoveryIsCapability:
+    def test_is_capability_subclass(self):
+        assert issubclass(ToolErrorRecovery, Capability)
+
+    def test_instance_is_capability(self):
+        assert isinstance(ToolErrorRecovery(), Capability)
+
+    def test_instructions_returns_none_when_clean(self):
+        recovery = ToolErrorRecovery()
+        ctx = RunContextWrapper(context=None)
+        assert recovery.instructions(ctx) is None
+
+    def test_instructions_returns_section_when_errors_tracked(self):
+        recovery = ToolErrorRecovery()
+        recovery.record_tool_result("my_tool", json.dumps({"error": "fail"}))
+        ctx = RunContextWrapper(context=None)
+        section = recovery.instructions(ctx)
+        assert section is not None
+        assert "Tool Error Recovery" in section
+
+    def test_instructions_matches_build_instruction_section(self):
+        recovery = ToolErrorRecovery()
+        recovery.record_tool_result("my_tool", json.dumps({"error": "fail"}))
+        ctx = RunContextWrapper(context=None)
+        assert recovery.instructions(ctx) == recovery.build_instruction_section()
+
+    def test_on_tool_start_then_end_records_error(self):
+        recovery = ToolErrorRecovery()
+        ctx = RunContextWrapper(context=None)
+        tool = Mock()
+        tool.name = "my_tool"
+
+        recovery.on_tool_start(ctx, tool, json.dumps({"q": "x"}))
+        recovery.on_tool_end(ctx, tool, json.dumps({"error": "fail"}))
+
+        summary = recovery.get_error_summary()
+        assert summary["my_tool"]["error"] == "fail"
+
+    def test_on_tool_end_uses_args_from_on_tool_start(self):
+        recovery = ToolErrorRecovery()
+        ctx = RunContextWrapper(context=None)
+        tool = Mock()
+        tool.name = "my_tool"
+
+        # Two identical-arg failures via the Capability hooks should be detected
+        # as identical retries.
+        args = json.dumps({"q": "x"})
+        for _ in range(2):
+            recovery.on_tool_start(ctx, tool, args)
+            recovery.on_tool_end(ctx, tool, json.dumps({"error": "fail"}))
+
+        summary = recovery.get_error_summary()
+        assert summary["my_tool"]["identical_count"] == 2
+
+    def test_tools_default_is_empty(self):
+        assert ToolErrorRecovery().tools() == []
+
+
+class TestToolErrorRecoveryClone:
+    def test_clone_returns_tool_error_recovery(self):
+        clone = ToolErrorRecovery().clone()
+        assert isinstance(clone, ToolErrorRecovery)
+
+    def test_clone_is_independent_instance(self):
+        original = ToolErrorRecovery()
+        clone = original.clone()
+        assert clone is not original
+
+    def test_clone_preserves_configuration(self):
+        registry = Mock()
+        original = ToolErrorRecovery(
+            tool_registry=registry,
+            mcp_hints={"mcp_search": "Use a longer query."},
+            max_identical_before_stop=5,
+        )
+        clone = original.clone()
+        assert clone._registry is registry
+        assert clone._mcp_hints == {"mcp_search": "Use a longer query."}
+        assert clone.max_identical_before_stop == 5
+
+    def test_clone_does_not_share_mcp_hints(self):
+        original = ToolErrorRecovery(mcp_hints={"a": "hint"})
+        clone = original.clone()
+        clone._mcp_hints["b"] = "new hint"
+        assert "b" not in original._mcp_hints
+
+    def test_clone_zeroes_error_state(self):
+        original = ToolErrorRecovery()
+        original.record_tool_result("t", json.dumps({"error": "old"}), json.dumps({"a": 1}))
+        original.on_tool_start(RunContextWrapper(context=None), Mock(name="pending_tool"), "{}")
+        assert original.has_errors
+
+        clone = original.clone()
+        assert not clone.has_errors
+        assert clone.get_error_summary() == {}
+        assert clone._last_args == {}
+        assert clone._pending_args == {}
+
+    def test_clone_does_not_mutate_original(self):
+        original = ToolErrorRecovery()
+        original.record_tool_result("t", json.dumps({"error": "keep"}), json.dumps({"a": 1}))
+
+        clone = original.clone()
+        clone.record_tool_result("t", json.dumps({"error": "fresh"}), json.dumps({"a": 2}))
+
+        # Original keeps its single tracked error untouched
+        assert original.get_error_summary()["t"]["error"] == "keep"
+        assert original.get_error_summary()["t"]["call_count"] == 1
+        assert clone.get_error_summary()["t"]["error"] == "fresh"
+
+
+class TestResetClearsPendingArgs:
+    def test_reset_clears_pending_args(self):
+        recovery = ToolErrorRecovery()
+        ctx = RunContextWrapper(context=None)
+        tool = Mock()
+        tool.name = "my_tool"
+        recovery.on_tool_start(ctx, tool, json.dumps({"q": "x"}))
+        assert recovery._pending_args  # in-flight
+
+        recovery.reset()
+        assert recovery._pending_args == {}
+
+
+# ------------------------------------------------------------------ #
+# Snapshot / rehydrate
+# ------------------------------------------------------------------ #
+
+
+def _record_failure(recovery: ToolErrorRecovery, tool_name: str, args: dict, message: str = "boom") -> None:
+    """Helper: simulate a single failed tool call."""
+    ctx = RunContextWrapper(context=None)
+    tool = Mock()
+    tool.name = tool_name
+    recovery.on_tool_start(ctx, tool, json.dumps(args))
+    recovery.on_tool_end(ctx, tool, json.dumps({"error": message}))
+
+
+class TestToolErrorRecoverySnapshot:
+    def test_snapshot_captures_tracked_errors(self):
+        recovery = ToolErrorRecovery()
+        _record_failure(recovery, "search", {"q": "x"}, "404")
+
+        snap = recovery.to_snapshot()
+        assert "search" in snap["errors"]
+        assert snap["errors"]["search"]["call_count"] == 1
+        assert snap["errors"]["search"]["error"] == "404"
+        assert "search" in snap["last_args"]
+
+    def test_round_trip_preserves_error_state(self):
+        # AC: same round-trip behavior for ToolErrorRecovery as TurnBudget.
+        original = ToolErrorRecovery(max_identical_before_stop=3)
+        _record_failure(original, "search", {"q": "a"}, "fail-1")
+        _record_failure(original, "search", {"q": "a"}, "fail-2")
+        _record_failure(original, "fetch", {"url": "u"}, "timeout")
+
+        snap = original.to_snapshot()
+
+        resumed = ToolErrorRecovery(max_identical_before_stop=3)
+        resumed.from_snapshot(snap)
+
+        assert resumed.has_errors
+        assert resumed._errors["search"].call_count == 2
+        assert resumed._errors["search"].identical_count == 2
+        assert resumed._errors["fetch"].call_count == 1
+        assert resumed._last_args["search"] == original._last_args["search"]
+        assert resumed._pending_args == {}
+
+    def test_snapshot_is_json_serializable(self):
+        recovery = ToolErrorRecovery()
+        _record_failure(recovery, "search", {"q": "x"})
+        json.dumps(recovery.to_snapshot())  # must not raise
+
+    def test_from_snapshot_tolerates_missing_keys(self):
+        recovery = ToolErrorRecovery()
+        recovery.from_snapshot({})
+        assert recovery._errors == {}
+        assert recovery._last_args == {}
+
+    def test_round_trip_preserves_instruction_escalation(self):
+        original = ToolErrorRecovery(max_identical_before_stop=3)
+        _record_failure(original, "search", {"q": "a"}, "fail")
+        _record_failure(original, "search", {"q": "a"}, "fail")
+        _record_failure(original, "search", {"q": "a"}, "fail")
+
+        resumed = ToolErrorRecovery(max_identical_before_stop=3)
+        resumed.from_snapshot(original.to_snapshot())
+        assert resumed.has_critical_errors
+        assert "STOP" in resumed.build_instruction_section()

--- a/tests/test_turn_budget.py
+++ b/tests/test_turn_budget.py
@@ -3,8 +3,10 @@
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
 
 import pytest
+from agents import RunContextWrapper
 
-from sinan_agentic_core.core.turn_budget import TurnBudget, TurnBudgetHooks
+from sinan_agentic_core.core.capabilities import Capability
+from sinan_agentic_core.core.turn_budget import TurnBudget
 
 
 # ------------------------------------------------------------------ #
@@ -205,25 +207,30 @@ class TestBuildInstructionSection:
 
 
 # ------------------------------------------------------------------ #
-# TurnBudgetHooks
+# TurnBudget — on_llm_start capability hook
 # ------------------------------------------------------------------ #
 
 
-class TestTurnBudgetHooks:
-    @pytest.mark.asyncio
-    async def test_on_llm_start_records_turn(self):
+class TestTurnBudgetOnLlmStart:
+    def test_on_llm_start_records_turn(self):
         budget = TurnBudget()
-        hooks = TurnBudgetHooks(budget)
-        await hooks.on_llm_start(Mock(), Mock(), None, [])
+        budget.on_llm_start(Mock(), Mock(), None, [])
         assert budget.turns_used == 1
 
-    @pytest.mark.asyncio
-    async def test_multiple_llm_starts(self):
+    def test_multiple_llm_starts(self):
         budget = TurnBudget()
-        hooks = TurnBudgetHooks(budget)
         for _ in range(5):
-            await hooks.on_llm_start(Mock(), Mock(), None, [])
+            budget.on_llm_start(Mock(), Mock(), None, [])
         assert budget.turns_used == 5
+
+    def test_on_llm_start_emits_event_when_streaming(self):
+        budget = TurnBudget(default_turns=10)
+        events: list[dict] = []
+        budget.on_event = events.append
+        budget.on_llm_start(Mock(), Mock(), None, [])
+        assert len(events) == 1
+        assert events[0]["event"] == "turn_budget"
+        assert events[0]["data"]["turns_used"] == 1
 
 
 # ------------------------------------------------------------------ #
@@ -317,25 +324,25 @@ class TestBaseAgentRunnerTurnBudget:
         ):
             return BaseAgentRunner()
 
-    def test_make_instructions_dynamic_from_static(self, runner):
+    def test_apply_dynamic_instructions_from_static(self, runner):
         agent = Mock()
         agent.instructions = "Static instructions."
         budget = TurnBudget(default_turns=10)
         budget.turns_used = 8
 
-        runner._make_instructions_dynamic(agent, budget)
+        runner._apply_dynamic_instructions(agent, [budget])
 
         assert callable(agent.instructions)
         result = agent.instructions(Mock(), Mock())
         assert "Static instructions." in result
         assert "remaining" in result and "10" in result
 
-    def test_make_instructions_dynamic_from_callable(self, runner):
+    def test_apply_dynamic_instructions_from_callable(self, runner):
         agent = Mock()
         agent.instructions = lambda ctx, a: "Dynamic base."
         budget = TurnBudget(default_turns=5)
 
-        runner._make_instructions_dynamic(agent, budget)
+        runner._apply_dynamic_instructions(agent, [budget])
 
         assert callable(agent.instructions)
         result = agent.instructions(Mock(), Mock())
@@ -344,6 +351,8 @@ class TestBaseAgentRunnerTurnBudget:
 
     @pytest.mark.asyncio
     async def test_execute_basic_with_budget(self, runner):
+        from sinan_agentic_core.core.base_runner import _CompositeHooks
+
         budget = TurnBudget(default_turns=10, absolute_max=25)
         context = Mock()
         session = Mock()
@@ -361,13 +370,13 @@ class TestBaseAgentRunnerTurnBudget:
 
                 result = await runner._execute_basic(
                     "test_agent", context, session, 25, "hello",
-                    turn_budget=budget,
+                    capabilities=[budget],
                 )
 
                 assert result == "test output"
                 # Verify hooks were passed
                 call_kwargs = MockRunner.run.call_args[1]
-                assert isinstance(call_kwargs["hooks"], TurnBudgetHooks)
+                assert isinstance(call_kwargs["hooks"], _CompositeHooks)
                 assert call_kwargs["max_turns"] == 25
 
     @pytest.mark.asyncio
@@ -388,7 +397,7 @@ class TestBaseAgentRunnerTurnBudget:
             call_args = mock_basic.call_args
             # sdk_max_turns should be absolute_max
             assert call_args[0][3] == 25  # max_turns positional arg
-            assert call_args[1]["turn_budget"] is budget
+            assert budget in call_args[1]["capabilities"]
 
     @pytest.mark.asyncio
     async def test_execute_attaches_budget_to_context(self, runner):
@@ -442,6 +451,161 @@ class TestBaseAgentRunnerTurnBudget:
 
 
 # ------------------------------------------------------------------ #
+# Capability protocol adoption
+# ------------------------------------------------------------------ #
+
+
+class TestTurnBudgetIsCapability:
+    def test_is_capability_subclass(self):
+        assert issubclass(TurnBudget, Capability)
+
+    def test_instance_is_capability(self):
+        assert isinstance(TurnBudget(), Capability)
+
+    def test_instructions_returns_initial_section(self):
+        budget = TurnBudget(default_turns=10)
+        ctx = RunContextWrapper(context=None)
+        section = budget.instructions(ctx)
+        assert section is not None
+        assert "10 turns" in section
+
+    def test_instructions_reflects_state(self):
+        budget = TurnBudget(default_turns=10, reminder_at=2)
+        budget.turns_used = 5
+        ctx = RunContextWrapper(context=None)
+        section = budget.instructions(ctx)
+        assert section is not None
+        assert "5 of 10" in section
+
+    def test_instructions_matches_build_instruction_section(self):
+        budget = TurnBudget(default_turns=10, reminder_at=2)
+        budget.turns_used = 9
+        ctx = RunContextWrapper(context=None)
+        assert budget.instructions(ctx) == budget.build_instruction_section()
+
+    def test_tools_returns_request_extension(self):
+        from sinan_agentic_core.core.turn_budget_tool import request_extension_tool
+        assert TurnBudget().tools() == [request_extension_tool]
+
+
+class TestTurnBudgetClone:
+    def test_clone_returns_turn_budget(self):
+        clone = TurnBudget().clone()
+        assert isinstance(clone, TurnBudget)
+
+    def test_clone_is_independent_instance(self):
+        original = TurnBudget(default_turns=10)
+        clone = original.clone()
+        assert clone is not original
+
+    def test_clone_preserves_configuration(self):
+        original = TurnBudget(
+            default_turns=8,
+            reminder_at=1,
+            max_extensions=4,
+            extension_size=3,
+            absolute_max=20,
+        )
+        clone = original.clone()
+        assert clone.default_turns == 8
+        assert clone.reminder_at == 1
+        assert clone.max_extensions == 4
+        assert clone.extension_size == 3
+        assert clone.absolute_max == 20
+
+    def test_clone_zeroes_counters(self):
+        original = TurnBudget(default_turns=10)
+        original.turns_used = 7
+        original.extensions_used = 2
+        original.extension_reasons.extend(["a", "b"])
+
+        clone = original.clone()
+        assert clone.turns_used == 0
+        assert clone.extensions_used == 0
+        assert clone.extension_reasons == []
+
+    def test_clone_does_not_mutate_original(self):
+        original = TurnBudget(default_turns=10)
+        original.turns_used = 4
+        original.extensions_used = 1
+        original.extension_reasons.append("keep me")
+
+        clone = original.clone()
+        clone.record_turn()
+        clone.request_extension("clone-only reason")
+
+        assert original.turns_used == 4
+        assert original.extensions_used == 1
+        assert original.extension_reasons == ["keep me"]
+
+    def test_clone_does_not_share_extension_reasons(self):
+        original = TurnBudget(default_turns=10)
+        original.extension_reasons.append("seed")
+        clone = original.clone()
+        assert clone.extension_reasons is not original.extension_reasons
+
+
+# ------------------------------------------------------------------ #
+# Snapshot / rehydrate
+# ------------------------------------------------------------------ #
+
+
+class TestTurnBudgetSnapshot:
+    def test_snapshot_serializes_counters(self):
+        budget = TurnBudget(default_turns=10)
+        budget.record_turn()
+        budget.record_turn()
+        budget.request_extension("need more")
+
+        snap = budget.to_snapshot()
+        assert snap == {
+            "turns_used": 2,
+            "extensions_used": 1,
+            "extension_reasons": ["need more"],
+        }
+
+    def test_round_trip_preserves_remaining_budget(self):
+        # AC: configure to 10 turns, advance to 4, snapshot, rehydrate, expect 6 remaining.
+        original = TurnBudget(default_turns=10)
+        for _ in range(4):
+            original.record_turn()
+        snap = original.to_snapshot()
+
+        resumed = TurnBudget(default_turns=10)
+        resumed.from_snapshot(snap)
+        assert resumed.turns_used == 4
+        assert resumed.remaining == 6
+        assert resumed.effective_max == 10
+
+    def test_round_trip_preserves_extensions(self):
+        original = TurnBudget(default_turns=5, extension_size=3, max_extensions=2)
+        original.request_extension("first")
+        original.record_turn()
+
+        resumed = TurnBudget(default_turns=5, extension_size=3, max_extensions=2)
+        resumed.from_snapshot(original.to_snapshot())
+
+        assert resumed.extensions_used == 1
+        assert resumed.effective_max == 8
+        assert resumed.remaining == 7
+        assert resumed.extension_reasons == ["first"]
+
+    def test_from_snapshot_tolerates_missing_keys(self):
+        budget = TurnBudget()
+        budget.from_snapshot({})  # must not raise
+        assert budget.turns_used == 0
+        assert budget.extensions_used == 0
+        assert budget.extension_reasons == []
+
+    def test_snapshot_is_json_serializable(self):
+        import json
+        budget = TurnBudget()
+        budget.record_turn()
+        budget.request_extension("why")
+        json.dumps(budget.to_snapshot())  # must not raise
+
+
+# ------------------------------------------------------------------ #
 # Top-level imports
 # ------------------------------------------------------------------ #
 
@@ -451,11 +615,6 @@ class TestTopLevelImports:
         from sinan_agentic_core import TurnBudget
         assert TurnBudget is not None
 
-    def test_turn_budget_hooks_importable(self):
-        from sinan_agentic_core import TurnBudgetHooks
-        assert TurnBudgetHooks is not None
-
     def test_turn_budget_from_core(self):
-        from sinan_agentic_core.core import TurnBudget, TurnBudgetHooks
+        from sinan_agentic_core.core import TurnBudget
         assert TurnBudget is not None
-        assert TurnBudgetHooks is not None


### PR DESCRIPTION
## Summary

Release v0.8.0 — introduces the **Capability** abstraction: a pluggable protocol for agent behaviors that replaces ad-hoc edits to `base_runner.py`. Existing systems (`TurnBudget`, `ToolErrorRecovery`) are refactored to implement the protocol with no behavior change.

## Commits

- `Epic: [EPIC] Introduce Capability abstraction for pluggable agent behaviors (#14)`
  - feat(capabilities): define Capability protocol and base class (#2)
  - refactor(capabilities): make TurnBudget a Capability (#3)
  - refactor(capabilities): make ToolErrorRecovery a Capability (#4)
- `docs: meta-docs for epic #1`
- `chore: bump version to 0.8.0`

## Test plan

- [x] `pytest` — 513 passed, 94% coverage
- [ ] CI green on staging branch