### PR TITLE
feat(llm): external LLM provider support (Azure OpenAI, OpenAI-compatible endpoints) (closes #13)

### DIFF
--- a/examples/azure_openai_agent.py
+++ b/examples/azure_openai_agent.py
@@ -1,0 +1,105 @@
+"""Example: run a simple chat against Azure OpenAI.
+
+Set the following environment variables before running::
+
+    export AZURE_OPENAI_API_KEY="..."
+    export AZURE_OPENAI_ENDPOINT="https://<resource>.openai.azure.com"
+    export AZURE_OPENAI_API_VERSION="2024-08-01-preview"
+    export AZURE_OPENAI_DEPLOYMENT="gpt-4o"
+
+The ``AZURE_OPENAI_DEPLOYMENT`` value is the deployment name in your Azure
+resource — it doubles as the ``model`` field on the ``AgentDefinition`` below.
+That value is forwarded verbatim as ``model=`` on the underlying SDK call, so
+deployments named after the model they back (e.g. deployment ``gpt-4o`` ->
+model ``gpt-4o``) let the same ``agents.yaml`` work across providers.
+
+Usage::
+
+    python examples/azure_openai_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from agents import Agent, Runner
+from pydantic import SecretStr
+
+from sinan_agentic_core import (
+    AgentDefinition,
+    AgentSession,
+    AzureOpenAIProviderConfig,
+    configure_llm_provider,
+    get_agent_registry,
+    register_agent,
+)
+
+
+def _build_provider_config() -> AzureOpenAIProviderConfig:
+    return AzureOpenAIProviderConfig(
+        api_key=SecretStr(os.environ["AZURE_OPENAI_API_KEY"]),
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_version=os.environ["AZURE_OPENAI_API_VERSION"],
+        azure_deployment=os.environ["AZURE_OPENAI_DEPLOYMENT"],
+    )
+
+
+def _register_agent(deployment: str) -> None:
+    register_agent(
+        AgentDefinition(
+            name="azure_assistant",
+            description="A friendly assistant running on Azure OpenAI",
+            instructions=(
+                "You are a concise, friendly assistant. Answer in one or two " "sentences."
+            ),
+            tools=[],
+            model=deployment,
+        )
+    )
+
+
+async def run() -> None:
+    config = _build_provider_config()
+    configure_llm_provider(config)
+
+    deployment = os.environ["AZURE_OPENAI_DEPLOYMENT"]
+    _register_agent(deployment)
+
+    agent_def = get_agent_registry().get("azure_assistant")
+    if agent_def is None:
+        raise RuntimeError("azure_assistant was not registered")
+
+    sdk_agent = Agent(
+        name=agent_def.name,
+        instructions=agent_def.instructions,
+        model=agent_def.model,
+        tools=[],
+    )
+
+    session = AgentSession(session_id="azure-example")
+    await session.add_items([{"role": "user", "content": "What is the capital of France?"}])
+
+    result = await Runner.run(
+        starting_agent=sdk_agent,
+        input=await session.get_items(),
+    )
+    print("Assistant:", result.final_output)
+
+
+def main() -> None:
+    required = (
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_OPENAI_API_VERSION",
+        "AZURE_OPENAI_DEPLOYMENT",
+    )
+    missing = [name for name in required if not os.environ.get(name)]
+    if missing:
+        print("Missing required environment variables:", ", ".join(missing))
+        return
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 
 dependencies = [
     "openai-agents>=0.8.0",  # OpenAI Agents SDK
+    "openai>=1.40",  # Direct AsyncOpenAI / AsyncAzureOpenAI client construction
     "pydantic>=2.0",
     "pyyaml>=6.0",
 ]

--- a/sinan_agentic_core/__init__.py
+++ b/sinan_agentic_core/__init__.py
@@ -39,40 +39,47 @@ Quick Start:
 
 from .core import BaseAgentRunner, Capability, ToolErrorRecovery, TurnBudget
 from .instructions import InstructionBuilder
-from .session import AgentSession, ConversationHistory, SQLiteSessionStore
+from .llm import (
+    AzureOpenAIProviderConfig,
+    LLMProviderConfig,
+    OpenAIProviderConfig,
+    configure_llm_provider,
+    load_llm_provider_config,
+    parse_llm_provider_config,
+)
 from .models.context import AgentContext
-from .models.outputs import ToolOutput, ChatResponse
+from .models.outputs import ChatResponse, ToolOutput
+from .orchestrator import AgentOrchestrator
 from .registry import (
     AgentCatalog,
+    AgentDefinition,
+    AgentRegistry,
     AgentYamlEntry,
     CapabilityFactory,
     CapabilityNotFoundError,
     CapabilityRef,
     CapabilityRegistry,
-    get_capability_registry,
-    register_capability,
-    load_agent_catalog,
-    AgentDefinition,
-    AgentRegistry,
-    get_agent_registry,
-    register_agent,
-    create_agent_from_registry,
     ToolCatalog,
-    ToolYamlEntry,
-    load_tool_catalog,
     ToolDefinition,
     ToolRegistry,
+    ToolYamlEntry,
+    create_agent_from_registry,
+    get_agent_registry,
+    get_capability_registry,
     get_tool_registry,
+    load_agent_catalog,
+    load_tool_catalog,
+    register_agent,
+    register_capability,
     register_tool,
 )
 from .services import (
     StreamingRunHooks,
     chat,
-    chat_with_hooks,
     chat_streamed,
+    chat_with_hooks,
 )
-
-from .orchestrator import AgentOrchestrator
+from .session import AgentSession, ConversationHistory, SQLiteSessionStore
 from .utils import tool_error, tool_response, unwrap_context
 
 # MCP support (optional — requires 'sinan_agentic_core[mcp]')
@@ -87,6 +94,13 @@ __all__ = [
     "TurnBudget",
     # Instructions
     "InstructionBuilder",
+    # LLM providers
+    "AzureOpenAIProviderConfig",
+    "LLMProviderConfig",
+    "OpenAIProviderConfig",
+    "configure_llm_provider",
+    "load_llm_provider_config",
+    "parse_llm_provider_config",
     # Session
     "AgentSession",
     "ConversationHistory",

--- a/sinan_agentic_core/llm/__init__.py
+++ b/sinan_agentic_core/llm/__init__.py
@@ -1,0 +1,27 @@
+"""External LLM provider support — public OpenAI and Azure OpenAI.
+
+Quick start::
+
+    from sinan_agentic_core.llm import load_llm_provider_config, configure_llm_provider
+
+    cfg = load_llm_provider_config("config.yaml")  # reads the top-level 'llm:' key
+    configure_llm_provider(cfg)
+"""
+
+from .config import (
+    AzureOpenAIProviderConfig,
+    LLMProviderConfig,
+    OpenAIProviderConfig,
+    parse_llm_provider_config,
+)
+from .factory import configure_llm_provider
+from .yaml_loader import load_llm_provider_config
+
+__all__ = [
+    "AzureOpenAIProviderConfig",
+    "LLMProviderConfig",
+    "OpenAIProviderConfig",
+    "configure_llm_provider",
+    "load_llm_provider_config",
+    "parse_llm_provider_config",
+]

--- a/sinan_agentic_core/llm/config.py
+++ b/sinan_agentic_core/llm/config.py
@@ -1,0 +1,85 @@
+"""Pydantic provider configs for the LLM layer.
+
+A single discriminated union (:data:`LLMProviderConfig`) covers public OpenAI
+and Azure OpenAI deployments. Other OpenAI-compatible endpoints (Together,
+OpenRouter, local proxies) reuse :class:`OpenAIProviderConfig` via ``base_url``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, TypeAdapter
+
+ApiMode = Literal["chat_completions", "responses"]
+
+
+class _BaseProviderConfig(BaseModel):
+    """Fields shared by every OpenAI-compatible provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    api_key: SecretStr
+    api_mode: ApiMode = "responses"
+    use_for_tracing: bool = True
+    disable_tracing: bool = False
+
+
+class OpenAIProviderConfig(_BaseProviderConfig):
+    """Public OpenAI (or any OpenAI-compatible endpoint via ``base_url``).
+
+    The ``model`` field on each agent in ``agents.yaml`` is forwarded verbatim
+    as the ``model=`` argument on the underlying SDK call (e.g. ``gpt-4o``).
+    """
+
+    provider: Literal["openai"] = "openai"
+    base_url: str | None = None
+    organization: str | None = None
+    project: str | None = None
+
+
+class AzureOpenAIProviderConfig(_BaseProviderConfig):
+    """Azure OpenAI deployment.
+
+    Azure exposes only the chat-completions API and rejects requests to the
+    public OpenAI tracing backend, so the defaults pin ``api_mode`` to
+    ``chat_completions`` and disable tracing.
+
+    The ``model`` field on each agent in ``agents.yaml`` is forwarded verbatim
+    as the ``model=`` argument on the underlying SDK call. On Azure that value
+    is the **deployment name**, not the underlying model id. The same
+    ``agents.yaml`` works across providers when Azure deployments are named
+    after the model they back (e.g. deployment ``gpt-4o`` -> model ``gpt-4o``).
+    """
+
+    provider: Literal["azure_openai"] = "azure_openai"
+    azure_endpoint: str
+    api_version: str
+    azure_deployment: str | None = None
+    api_mode: ApiMode = "chat_completions"
+    use_for_tracing: bool = False
+    disable_tracing: bool = True
+
+
+LLMProviderConfig = Annotated[
+    OpenAIProviderConfig | AzureOpenAIProviderConfig,
+    Field(discriminator="provider"),
+]
+"""Discriminated union of every supported provider config."""
+
+
+_LLM_PROVIDER_ADAPTER: TypeAdapter[OpenAIProviderConfig | AzureOpenAIProviderConfig] = TypeAdapter(
+    LLMProviderConfig
+)
+
+
+def parse_llm_provider_config(
+    data: dict[str, Any],
+) -> OpenAIProviderConfig | AzureOpenAIProviderConfig:
+    """Validate a raw mapping against :data:`LLMProviderConfig`.
+
+    Raises :class:`pydantic.ValidationError` for unknown providers or invalid
+    fields (the ``provider`` discriminator rejects anything that is not
+    ``openai`` or ``azure_openai``).
+    """
+    return _LLM_PROVIDER_ADAPTER.validate_python(data)

--- a/sinan_agentic_core/llm/factory.py
+++ b/sinan_agentic_core/llm/factory.py
@@ -1,0 +1,70 @@
+"""Build an OpenAI client from a provider config and register it as the SDK default.
+
+This is the single entry point that consumers call once at process start. It
+hides the SDK setters (``set_default_openai_client``, ``set_default_openai_api``,
+``set_tracing_disabled``) so callers never reach into ``agents.*`` internals.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from agents import (
+    set_default_openai_api,
+    set_default_openai_client,
+    set_tracing_disabled,
+)
+from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+from .config import AzureOpenAIProviderConfig, OpenAIProviderConfig
+
+logger = logging.getLogger(__name__)
+
+
+def configure_llm_provider(
+    config: OpenAIProviderConfig | AzureOpenAIProviderConfig,
+) -> AsyncOpenAI:
+    """Build the right ``AsyncOpenAI`` / ``AsyncAzureOpenAI`` client and wire it
+    into the OpenAI Agents SDK.
+
+    Side effects:
+      - Calls :func:`agents.set_default_openai_client` with ``use_for_tracing``
+        from *config*.
+      - Calls :func:`agents.set_default_openai_api` with ``config.api_mode``.
+      - Calls :func:`agents.set_tracing_disabled` when ``config.disable_tracing``
+        is true.
+
+    Returns:
+        The constructed client. Most callers ignore it; return it so callers
+        that need to make raw OpenAI calls (e.g. embeddings) can reuse it.
+    """
+    client = _build_client(config)
+    set_default_openai_client(client, use_for_tracing=config.use_for_tracing)
+    set_default_openai_api(config.api_mode)
+    if config.disable_tracing:
+        set_tracing_disabled(True)
+    logger.info(
+        "Configured LLM provider %r (api_mode=%s, tracing=%s)",
+        config.provider,
+        config.api_mode,
+        "off" if config.disable_tracing else "on",
+    )
+    return client
+
+
+def _build_client(
+    config: OpenAIProviderConfig | AzureOpenAIProviderConfig,
+) -> AsyncOpenAI:
+    if isinstance(config, AzureOpenAIProviderConfig):
+        return AsyncAzureOpenAI(
+            api_key=config.api_key.get_secret_value(),
+            azure_endpoint=config.azure_endpoint,
+            api_version=config.api_version,
+            azure_deployment=config.azure_deployment,
+        )
+    return AsyncOpenAI(
+        api_key=config.api_key.get_secret_value(),
+        base_url=config.base_url,
+        organization=config.organization,
+        project=config.project,
+    )

--- a/sinan_agentic_core/llm/yaml_loader.py
+++ b/sinan_agentic_core/llm/yaml_loader.py
@@ -1,0 +1,99 @@
+"""YAML loader for LLM provider configs with ``${VAR}`` env interpolation.
+
+Secrets must not live in YAML — instead, write ``${OPENAI_API_KEY}`` and
+populate the environment at process start. Missing variables raise
+:class:`KeyError` so a typo or a forgotten ``export`` fails loudly rather
+than silently falling back to an empty string.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from .config import (
+    AzureOpenAIProviderConfig,
+    OpenAIProviderConfig,
+    parse_llm_provider_config,
+)
+
+_ENV_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def load_llm_provider_config(
+    path: str | Path,
+    section: str = "llm",
+) -> OpenAIProviderConfig | AzureOpenAIProviderConfig:
+    """Load and validate a provider config from *path*.
+
+    Args:
+        path: Path to a YAML file. The file must contain a top-level mapping
+            with a *section* key holding the provider config.
+        section: Top-level key under which the provider config lives.
+            Defaults to ``"llm"``.
+
+    Raises:
+        ImportError: If PyYAML is not installed.
+        FileNotFoundError: If *path* does not exist.
+        KeyError: If the section is missing or an interpolated environment
+            variable is not set.
+        pydantic.ValidationError: If the config does not match a supported
+            provider shape.
+    """
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError(
+            "PyYAML is required for load_llm_provider_config. "
+            "Install it with: pip install pyyaml"
+        ) from exc
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"LLM provider config not found at {path}")
+
+    with open(path, encoding="utf-8") as f:
+        data: dict[str, Any] = yaml.safe_load(f) or {}
+
+    if section not in data:
+        raise KeyError(
+            f"Section '{section}' not found in {path}. "
+            f"Available top-level keys: {sorted(data.keys()) or '<none>'}"
+        )
+
+    raw = data[section]
+    if not isinstance(raw, dict):
+        raise TypeError(
+            f"Section '{section}' in {path} must be a mapping, got " f"{type(raw).__name__}."
+        )
+
+    interpolated = _interpolate_env(raw)
+    return parse_llm_provider_config(interpolated)
+
+
+def _interpolate_env(value: Any) -> Any:
+    """Recursively replace ``${VAR}`` placeholders with environment values.
+
+    Strings that consist solely of one placeholder are replaced with the raw
+    env value; mixed strings (``"prefix-${X}-suffix"``) get string
+    substitution. Missing variables raise :class:`KeyError`.
+    """
+    if isinstance(value, str):
+        return _interpolate_string(value)
+    if isinstance(value, dict):
+        return {k: _interpolate_env(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_interpolate_env(v) for v in value]
+    return value
+
+
+def _interpolate_string(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        if var not in os.environ:
+            raise KeyError(f"Environment variable '{var}' referenced in LLM config " f"is not set.")
+        return os.environ[var]
+
+    return _ENV_PATTERN.sub(replace, text)

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,224 @@
+"""Tests for the ``sinan_agentic_core.llm`` provider config layer."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from openai import AsyncAzureOpenAI, AsyncOpenAI
+from pydantic import SecretStr, ValidationError
+
+from sinan_agentic_core.llm import (
+    AzureOpenAIProviderConfig,
+    OpenAIProviderConfig,
+    configure_llm_provider,
+    load_llm_provider_config,
+    parse_llm_provider_config,
+)
+from sinan_agentic_core.llm import factory as factory_module
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_sdk_calls(monkeypatch):
+    """Replace the SDK setters with no-op recorders."""
+    calls: dict[str, object] = {}
+
+    def fake_set_default_openai_client(client, use_for_tracing=True):
+        calls["client"] = client
+        calls["use_for_tracing"] = use_for_tracing
+
+    def fake_set_default_openai_api(api):
+        calls["api"] = api
+
+    def fake_set_tracing_disabled(disabled):
+        calls["tracing_disabled"] = disabled
+
+    monkeypatch.setattr(factory_module, "set_default_openai_client", fake_set_default_openai_client)
+    monkeypatch.setattr(factory_module, "set_default_openai_api", fake_set_default_openai_api)
+    monkeypatch.setattr(factory_module, "set_tracing_disabled", fake_set_tracing_disabled)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# parse_llm_provider_config — discriminator and defaults
+# ---------------------------------------------------------------------------
+
+
+class TestParseProviderConfig:
+    def test_openai_defaults(self):
+        cfg = parse_llm_provider_config({"provider": "openai", "api_key": "sk-test"})
+        assert isinstance(cfg, OpenAIProviderConfig)
+        assert cfg.api_mode == "responses"
+        assert cfg.use_for_tracing is True
+        assert cfg.disable_tracing is False
+        assert cfg.api_key.get_secret_value() == "sk-test"
+
+    def test_azure_defaults(self):
+        cfg = parse_llm_provider_config(
+            {
+                "provider": "azure_openai",
+                "api_key": "az-test",
+                "azure_endpoint": "https://example.openai.azure.com",
+                "api_version": "2024-08-01-preview",
+            }
+        )
+        assert isinstance(cfg, AzureOpenAIProviderConfig)
+        assert cfg.api_mode == "chat_completions"
+        assert cfg.disable_tracing is True
+        assert cfg.use_for_tracing is False
+
+    def test_unknown_provider_rejected(self):
+        with pytest.raises(ValidationError):
+            parse_llm_provider_config({"provider": "bedrock", "api_key": "x"})
+
+    def test_missing_provider_rejected(self):
+        with pytest.raises(ValidationError):
+            parse_llm_provider_config({"api_key": "sk-test"})
+
+    def test_azure_requires_endpoint(self):
+        with pytest.raises(ValidationError):
+            parse_llm_provider_config(
+                {
+                    "provider": "azure_openai",
+                    "api_key": "az",
+                    "api_version": "2024-08-01-preview",
+                }
+            )
+
+    def test_extra_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            parse_llm_provider_config({"provider": "openai", "api_key": "sk", "unknown": "x"})
+
+
+# ---------------------------------------------------------------------------
+# configure_llm_provider — SDK wiring
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureLLMProvider:
+    def test_openai_wires_responses_api_and_tracing(self, captured_sdk_calls):
+        cfg = OpenAIProviderConfig(api_key=SecretStr("sk-test"))
+        client = configure_llm_provider(cfg)
+
+        assert isinstance(client, AsyncOpenAI)
+        assert not isinstance(client, AsyncAzureOpenAI)
+        assert captured_sdk_calls["client"] is client
+        assert captured_sdk_calls["api"] == "responses"
+        assert captured_sdk_calls["use_for_tracing"] is True
+        assert "tracing_disabled" not in captured_sdk_calls
+
+    def test_openai_with_base_url_and_org(self, captured_sdk_calls):
+        cfg = OpenAIProviderConfig(
+            api_key=SecretStr("sk-test"),
+            base_url="https://proxy.example.com/v1",
+            organization="org-abc",
+            project="proj-xyz",
+        )
+        client = configure_llm_provider(cfg)
+        # AsyncOpenAI normalises base_url with a trailing slash
+        assert str(client.base_url).startswith("https://proxy.example.com/v1")
+        assert client.organization == "org-abc"
+        assert client.project == "proj-xyz"
+
+    def test_azure_wires_chat_completions_and_disables_tracing(self, captured_sdk_calls):
+        cfg = AzureOpenAIProviderConfig(
+            api_key=SecretStr("az-test"),
+            azure_endpoint="https://example.openai.azure.com",
+            api_version="2024-08-01-preview",
+            azure_deployment="gpt-4o",
+        )
+        client = configure_llm_provider(cfg)
+
+        assert isinstance(client, AsyncAzureOpenAI)
+        assert captured_sdk_calls["client"] is client
+        assert captured_sdk_calls["api"] == "chat_completions"
+        assert captured_sdk_calls["use_for_tracing"] is False
+        assert captured_sdk_calls["tracing_disabled"] is True
+
+    def test_disable_tracing_flag_respected_for_openai(self, captured_sdk_calls):
+        cfg = OpenAIProviderConfig(
+            api_key=SecretStr("sk-test"),
+            disable_tracing=True,
+            use_for_tracing=False,
+        )
+        configure_llm_provider(cfg)
+        assert captured_sdk_calls["tracing_disabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# load_llm_provider_config — YAML + ${VAR} interpolation
+# ---------------------------------------------------------------------------
+
+
+class TestLoadLLMProviderConfig:
+    def test_loads_openai_with_env_interpolation(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("MY_OPENAI_KEY", "sk-from-env")
+        path = tmp_path / "llm.yaml"
+        path.write_text(textwrap.dedent("""
+                llm:
+                  provider: openai
+                  api_key: ${MY_OPENAI_KEY}
+                """).strip())
+        cfg = load_llm_provider_config(path)
+        assert isinstance(cfg, OpenAIProviderConfig)
+        assert cfg.api_key.get_secret_value() == "sk-from-env"
+
+    def test_loads_azure_with_mixed_string_interpolation(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("AZ_KEY", "az-secret")
+        monkeypatch.setenv("AZ_RESOURCE", "my-resource")
+        path = tmp_path / "llm.yaml"
+        path.write_text(textwrap.dedent("""
+                llm:
+                  provider: azure_openai
+                  api_key: ${AZ_KEY}
+                  azure_endpoint: https://${AZ_RESOURCE}.openai.azure.com
+                  api_version: 2024-08-01-preview
+                  azure_deployment: gpt-4o
+                """).strip())
+        cfg = load_llm_provider_config(path)
+        assert isinstance(cfg, AzureOpenAIProviderConfig)
+        assert cfg.api_key.get_secret_value() == "az-secret"
+        assert cfg.azure_endpoint == "https://my-resource.openai.azure.com"
+
+    def test_missing_env_var_raises_key_error(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        path = tmp_path / "llm.yaml"
+        path.write_text(textwrap.dedent("""
+                llm:
+                  provider: openai
+                  api_key: ${MISSING_VAR}
+                """).strip())
+        with pytest.raises(KeyError, match="MISSING_VAR"):
+            load_llm_provider_config(path)
+
+    def test_custom_section(self, tmp_path: Path):
+        path = tmp_path / "llm.yaml"
+        path.write_text(textwrap.dedent("""
+                openai_cfg:
+                  provider: openai
+                  api_key: sk-flat
+                """).strip())
+        cfg = load_llm_provider_config(path, section="openai_cfg")
+        assert isinstance(cfg, OpenAIProviderConfig)
+        assert cfg.api_key.get_secret_value() == "sk-flat"
+
+    def test_missing_section_raises(self, tmp_path: Path):
+        path = tmp_path / "llm.yaml"
+        path.write_text("other:\n  foo: 1\n")
+        with pytest.raises(KeyError, match="llm"):
+            load_llm_provider_config(path)
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            load_llm_provider_config(tmp_path / "nope.yaml")
+
+    def test_section_must_be_mapping(self, tmp_path: Path):
+        path = tmp_path / "llm.yaml"
+        path.write_text("llm:\n  - not\n  - a\n  - mapping\n")
+        with pytest.raises(TypeError):
+            load_llm_provider_config(path)

--- a/uv.lock
+++ b/uv.lock
@@ -1504,9 +1504,10 @@ wheels = [
 
 [[package]]
 name = "sinan-agentic-core"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
+    { name = "openai" },
     { name = "openai-agents" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -1532,6 +1533,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "openai", specifier = ">=1.40" },
     { name = "openai-agents", specifier = ">=0.8.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },


### PR DESCRIPTION
## Summary

Adds `sinan_agentic_core/llm/` with discriminated provider configs (OpenAI / Azure OpenAI), a `configure_llm_provider` factory that wires the right `AsyncOpenAI` / `AsyncAzureOpenAI` client into the OpenAI Agents SDK, and a YAML loader with `${ENV_VAR}` interpolation. Includes tests and an Azure example.

Closes #13.

## Test plan

- [ ] `pytest tests/test_llm_provider.py` green
- [ ] `examples/azure_openai_agent.py` runs end-to-end against an Azure deployment
- [ ] `mypy --strict`, `ruff`, `black` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)