### PR TITLE
chore: sync uv.lock with 0.9.0 version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,10 @@ jobs:
       - name: Pytest
         run: pytest --cov=sinan_agentic_core --cov-report=term-missing
 
-  # Lint job runs separately and is non-required for now (#13/#1447 follow-up).
-  # The repo has pre-existing ruff/black/mypy violations from before CI existed;
-  # cleanup is tracked as a separate issue rather than blocking every PR until
-  # someone gets around to it. Once the backlog clears, flip ``continue-on-error``
-  # off and the lint signal becomes a hard gate.
+  # Lint job runs separately and is a hard gate after #20 (ruff) and #22 (mypy)
+  # cleared the pre-existing violations.
   lint:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/examples/context_and_session.py
+++ b/examples/context_and_session.py
@@ -14,38 +14,39 @@ Usage:
 import asyncio
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any
 
-from agents import Agent, Runner, RunContextWrapper, function_tool
+from agents import Agent, RunContextWrapper, Runner, function_tool
 
 from sinan_agentic_core import AgentSession
-
 
 # =============================================================================
 # 1. Define Custom Context
 # =============================================================================
 
+
 @dataclass
 class ConversationContext:
     """Context that carries data through the conversation.
-    
+
     This data is:
     - Accessible in tools via ctx.context
     - Accessible in dynamic instructions
     - Persists across multiple agent runs
     """
+
     # User information (set at start)
     user_id: str
     user_name: str
     role: str = "user"
-    
+
     # User preferences
-    preferences: Dict[str, Any] = field(default_factory=dict)
-    
+    preferences: dict[str, Any] = field(default_factory=dict)
+
     # Data accumulated during conversation
-    facts_learned: List[str] = field(default_factory=list)
-    topics_discussed: List[str] = field(default_factory=list)
-    
+    facts_learned: list[str] = field(default_factory=list)
+    topics_discussed: list[str] = field(default_factory=list)
+
     # Summary of previous conversation (for long conversations)
     conversation_summary: str = ""
 
@@ -54,14 +55,15 @@ class ConversationContext:
 # 2. Dynamic Instructions Function
 # =============================================================================
 
+
 def build_instructions(ctx: RunContextWrapper[ConversationContext], agent: Agent) -> str:
     """Build personalized instructions based on context.
-    
+
     This function is called each time the agent runs, allowing
     the instructions to reflect the current state of the context.
     """
     c = ctx.context
-    
+
     instructions = f"""You are a helpful assistant for {c.user_name}.
 User ID: {c.user_id}
 User role: {c.role}
@@ -74,26 +76,26 @@ Your capabilities:
 
 Be friendly and personalized. Reference facts you've learned when relevant.
 """
-    
+
     # Add preferences if available
     if c.preferences:
         prefs_str = ", ".join(f"{k}: {v}" for k, v in c.preferences.items())
         instructions += f"\nUser preferences: {prefs_str}"
-    
+
     # Add learned facts
     if c.facts_learned:
         instructions += "\n\nFacts you've learned about this user:"
         for fact in c.facts_learned:
             instructions += f"\n- {fact}"
-    
+
     # Add topics discussed
     if c.topics_discussed:
         instructions += f"\n\nTopics discussed so far: {', '.join(c.topics_discussed)}"
-    
+
     # Add conversation summary if available
     if c.conversation_summary:
         instructions += f"\n\nPrevious conversation summary:\n{c.conversation_summary}"
-    
+
     return instructions
 
 
@@ -101,13 +103,14 @@ Be friendly and personalized. Reference facts you've learned when relevant.
 # 3. Tools That Update Context
 # =============================================================================
 
+
 @function_tool
 def remember_fact(ctx: RunContextWrapper[ConversationContext], fact: str) -> str:
     """Store a fact about the user for future reference.
-    
+
     Use this when the user shares information about themselves,
     their preferences, or anything worth remembering.
-    
+
     Args:
         fact: A fact to remember about the user
     """
@@ -119,7 +122,7 @@ def remember_fact(ctx: RunContextWrapper[ConversationContext], fact: str) -> str
 @function_tool
 def note_topic(ctx: RunContextWrapper[ConversationContext], topic: str) -> str:
     """Note a topic that was discussed.
-    
+
     Args:
         topic: The topic being discussed
     """
@@ -132,7 +135,7 @@ def note_topic(ctx: RunContextWrapper[ConversationContext], topic: str) -> str:
 def get_user_profile(ctx: RunContextWrapper[ConversationContext]) -> str:
     """Get the current user's profile from context."""
     c = ctx.context
-    
+
     profile = f"""User Profile:
 - Name: {c.user_name}
 - ID: {c.user_id}
@@ -140,7 +143,7 @@ def get_user_profile(ctx: RunContextWrapper[ConversationContext]) -> str:
 - Preferences: {c.preferences}
 - Facts learned: {c.facts_learned}
 - Topics discussed: {c.topics_discussed}"""
-    
+
     return profile
 
 
@@ -160,17 +163,18 @@ agent = Agent[ConversationContext](
 # 5. Main Conversation Loop
 # =============================================================================
 
+
 async def run_conversation():
     """Run an interactive conversation with context and session management."""
-    
+
     print("=" * 60)
     print("Context and Session Example")
     print("=" * 60)
-    
+
     # Get user info
     user_name = input("What's your name? ").strip() or "User"
     role = input("What's your role? (user/developer/admin) ").strip() or "user"
-    
+
     # Initialize context with user data
     context = ConversationContext(
         user_id=f"user-{hash(user_name) % 10000}",
@@ -181,28 +185,28 @@ async def run_conversation():
             "detail_level": "moderate",
         },
     )
-    
+
     # Initialize session for conversation history
     session = AgentSession(
         session_id=f"session-{context.user_id}",
         max_items=50,
     )
-    
+
     print(f"\nHello {user_name}! I'm your assistant with memory.")
     print("I can remember facts about you and recall them later.")
     print("Try telling me about yourself, then ask what I know about you.")
     print("Type 'quit' to exit, 'status' to see context state.\n")
-    
+
     while True:
         user_input = input("You: ").strip()
-        
+
         if not user_input:
             continue
-        
+
         if user_input.lower() == "quit":
             print("\nGoodbye!")
             break
-        
+
         if user_input.lower() == "status":
             print("\n--- Context State ---")
             print(f"User: {context.user_name} ({context.user_id})")
@@ -213,32 +217,32 @@ async def run_conversation():
             print(f"Session messages: {session.get_message_count()}")
             print("-------------------\n")
             continue
-        
+
         # Add user message to session history
         await session.add_items([{"role": "user", "content": user_input}])
-        
+
         try:
             # Get conversation history
             history = await session.get_items()
-            
+
             # Run agent with both context and history
             result = await Runner.run(
                 agent,
-                input=history,      # Conversation history
-                context=context,    # Workflow state
+                input=history,  # Conversation history
+                context=context,  # Workflow state
             )
-            
+
             response = result.final_output
-            
+
             # Add assistant response to session
             await session.add_items([{"role": "assistant", "content": response}])
-            
+
             print(f"\nAssistant: {response}\n")
-            
+
             # Show what was learned (for demo purposes)
             if context.facts_learned:
                 print(f"  [Facts in memory: {len(context.facts_learned)}]")
-            
+
         except Exception as e:
             print(f"\nError: {e}\n")
 
@@ -249,7 +253,7 @@ async def main():
         print("Error: OPENAI_API_KEY not set")
         print("Run: export OPENAI_API_KEY='your-key'")
         return
-    
+
     await run_conversation()
 
 

--- a/examples/custom_capability.py
+++ b/examples/custom_capability.py
@@ -29,7 +29,6 @@ from sinan_agentic_core import (
     register_tool,
 )
 
-
 # =============================================================================
 # 1. A custom Capability: log every tool call
 # =============================================================================
@@ -94,17 +93,19 @@ async def get_current_time(ctx) -> dict:
 # each one before every execute() call so concurrent runs stay isolated.
 logger_capability = ToolCallLogger(prefix="[trace]")
 
-register_agent(AgentDefinition(
-    name="time_assistant",
-    description="Tells the user the current time",
-    instructions=(
-        "You are a helpful assistant. When the user asks for the time, "
-        "call the get_current_time tool and report the result."
-    ),
-    tools=["get_current_time"],
-    model="gpt-4o-mini",
-    capabilities=[logger_capability],
-))
+register_agent(
+    AgentDefinition(
+        name="time_assistant",
+        description="Tells the user the current time",
+        instructions=(
+            "You are a helpful assistant. When the user asks for the time, "
+            "call the get_current_time tool and report the result."
+        ),
+        tools=["get_current_time"],
+        model="gpt-4o-mini",
+        capabilities=[logger_capability],
+    )
+)
 
 
 # =============================================================================
@@ -130,8 +131,10 @@ async def run() -> None:
     # The template is untouched - the runner ran on a clone. Either inspect
     # the clone via streaming events, or pass a fresh ToolCallLogger as a
     # runtime kwarg if you need to read its trace after the run.
-    print(f"\nTemplate ToolCallLogger.calls (still empty - clones are isolated):"
-          f" {logger_capability.calls}")
+    print(
+        f"\nTemplate ToolCallLogger.calls (still empty - clones are isolated):"
+        f" {logger_capability.calls}"
+    )
 
 
 async def main() -> None:

--- a/examples/simple_chat_agent.py
+++ b/examples/simple_chat_agent.py
@@ -13,23 +13,21 @@ from datetime import datetime
 
 # Ensure OpenAI API key is set
 # export OPENAI_API_KEY="your-key"
-
-from agents import function_tool, Agent, Runner
+from agents import Agent, Runner, function_tool
 
 from sinan_agentic_core import (
     AgentDefinition,
     AgentSession,
-    AgentContext,
-    register_agent,
-    register_tool,
     get_agent_registry,
     get_tool_registry,
+    register_agent,
+    register_tool,
 )
-
 
 # =============================================================================
 # Step 1: Define Tools
 # =============================================================================
+
 
 @register_tool(
     name="get_current_time",
@@ -39,11 +37,7 @@ from sinan_agentic_core import (
 @function_tool
 async def get_current_time(ctx) -> dict:
     """Get the current time in ISO format."""
-    return {
-        "success": True,
-        "current_time": datetime.now().isoformat(),
-        "timezone": "local"
-    }
+    return {"success": True, "current_time": datetime.now().isoformat(), "timezone": "local"}
 
 
 @register_tool(
@@ -54,7 +48,7 @@ async def get_current_time(ctx) -> dict:
 @function_tool
 async def calculate(ctx, expression: str) -> dict:
     """Safely evaluate a math expression.
-    
+
     Args:
         expression: A mathematical expression like "2 + 2" or "10 * 5"
     """
@@ -63,7 +57,7 @@ async def calculate(ctx, expression: str) -> dict:
         allowed_chars = set("0123456789+-*/(). ")
         if not all(c in allowed_chars for c in expression):
             return {"success": False, "error": "Invalid characters in expression"}
-        
+
         result = eval(expression)  # Only safe because we validated input
         return {"success": True, "result": result}
     except Exception as e:
@@ -101,21 +95,22 @@ register_agent(assistant_agent)
 # Step 3: Run the Agent
 # =============================================================================
 
+
 async def run_chat():
     """Run an interactive chat session with the agent."""
-    
+
     # Get registries
     agent_registry = get_agent_registry()
     tool_registry = get_tool_registry()
-    
+
     # Get agent definition
     agent_def = agent_registry.get("assistant")
     if not agent_def:
         raise ValueError("Agent 'assistant' not found in registry")
-    
+
     # Build list of actual tool functions
     tools = tool_registry.get_tool_functions(agent_def.tools)
-    
+
     # Create the SDK Agent
     agent = Agent(
         name=agent_def.name,
@@ -123,27 +118,27 @@ async def run_chat():
         model=agent_def.model,
         tools=tools,
     )
-    
+
     # Create session for conversation history
     session = AgentSession(session_id="chat-session-1")
-    
+
     print("=" * 60)
     print("🤖 Simple Chat Agent")
     print("=" * 60)
     print("Type 'quit' to exit, 'history' to see conversation history")
     print()
-    
+
     while True:
         # Get user input
         user_input = input("You: ").strip()
-        
+
         if not user_input:
             continue
-        
+
         if user_input.lower() == "quit":
             print("Goodbye! 👋")
             break
-        
+
         if user_input.lower() == "history":
             history = await session.get_items()
             print(f"\n📜 Conversation History ({len(history)} messages):")
@@ -153,48 +148,42 @@ async def run_chat():
                 print(f"  {i}. [{role}] {content}")
             print()
             continue
-        
+
         # Add user message to session
-        await session.add_items([{
-            "role": "user",
-            "content": user_input
-        }])
-        
+        await session.add_items([{"role": "user", "content": user_input}])
+
         # Run the agent
         try:
             # Get conversation history for context
             history = await session.get_items()
-            
+
             # Run agent with Runner
             result = await Runner.run(
                 starting_agent=agent,
                 input=history,  # Pass full conversation history
             )
-            
+
             # Extract response
             response = result.final_output
-            
+
             # Add assistant response to session
-            await session.add_items([{
-                "role": "assistant", 
-                "content": response
-            }])
-            
+            await session.add_items([{"role": "assistant", "content": response}])
+
             print(f"\n🤖 Assistant: {response}\n")
-            
+
         except Exception as e:
             print(f"\n❌ Error: {e}\n")
 
 
 async def main():
     """Main entry point."""
-    
+
     # Check for API key
     if not os.environ.get("OPENAI_API_KEY"):
         print("⚠️  Warning: OPENAI_API_KEY not set!")
         print("Run: export OPENAI_API_KEY='your-key'")
         return
-    
+
     await run_chat()
 
 

--- a/examples/yaml_capabilities/run.py
+++ b/examples/yaml_capabilities/run.py
@@ -28,7 +28,6 @@ from sinan_agentic_core import (
     register_capability,
 )
 
-
 # ---------------------------------------------------------------------------
 # Custom capability — registered under a name that agents.yaml can reference.
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ target-version = ["py310", "py311", "py312"]
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 ignore = ["E501"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0",
     "mcp>=1.0.0",
+    "types-PyYAML>=6.0",
 ]
 
 [project.urls]

--- a/sinan_agentic_core/__init__.py
+++ b/sinan_agentic_core/__init__.py
@@ -19,7 +19,7 @@ Quick Start:
         register_tool,
         AgentDefinition
     )
-    
+
     # Define your agent
     my_agent = AgentDefinition(
         name="my_agent",
@@ -28,7 +28,7 @@ Quick Start:
         tools=["my_tool"]
     )
     register_agent(my_agent)
-    
+
     # Run orchestrator
     orchestrator = AgentOrchestrator()
     result = await orchestrator.run(

--- a/sinan_agentic_core/agents/__init__.py
+++ b/sinan_agentic_core/agents/__init__.py
@@ -4,7 +4,7 @@ Define your agents here by creating AgentDefinition instances and registering th
 
 Example:
     from sinan_agentic_core.registry import AgentDefinition, register_agent
-    
+
     my_agent = AgentDefinition(
         name="analyzer",
         description="Analyzes data and provides insights",

--- a/sinan_agentic_core/core/base_runner.py
+++ b/sinan_agentic_core/core/base_runner.py
@@ -8,15 +8,24 @@ Also retains run_agent() for backward compatibility.
 
 import json
 import logging
-from typing import Optional, Dict, Any, List, Callable
+from collections.abc import Callable
+from typing import Any
 
-from agents import Agent, Runner, RunContextWrapper, RunHooks, ItemHelpers, Usage
+from agents import (
+    Agent,
+    ItemHelpers,
+    ModelSettings,
+    RunContextWrapper,
+    RunHooks,
+    Runner,
+    Usage,
+)
 from openai.types.responses import ResponseCompletedEvent, ResponseTextDeltaEvent
 
-from ..session import AgentSession
-from ..models.context import AgentContext
 from ..models import outputs as output_models
-from ..registry import get_agent_registry, get_tool_registry, get_guardrail_registry
+from ..models.context import AgentContext
+from ..registry import get_agent_registry, get_guardrail_registry, get_tool_registry
+from ..session import AgentSession
 from .capabilities import Capability
 from .errors import structured_tool_error
 from .tool_error_recovery import ToolErrorRecovery
@@ -43,11 +52,10 @@ class BaseAgentRunner:
         self.agent_registry = get_agent_registry()
         self.tool_registry = get_tool_registry()
         self.guardrail_registry = get_guardrail_registry()
-        self.last_usage: Optional[Dict[str, Any]] = None
+        self.last_usage: dict[str, Any] | None = None
 
         self.tool_map = {
-            name: tool_def.function
-            for name, tool_def in self.tool_registry._tools.items()
+            name: tool_def.function for name, tool_def in self.tool_registry._tools.items()
         }
 
         self.guardrail_map = {
@@ -56,7 +64,9 @@ class BaseAgentRunner:
         }
 
         logger.debug(f"Loaded {len(self.tool_map)} tools: {list(self.tool_map.keys())}")
-        logger.debug(f"Loaded {len(self.guardrail_map)} guardrails: {list(self.guardrail_map.keys())}")
+        logger.debug(
+            f"Loaded {len(self.guardrail_map)} guardrails: {list(self.guardrail_map.keys())}"
+        )
 
     def setup_context(self, **context_data) -> AgentContext:
         """Setup context with provided data.
@@ -71,8 +81,8 @@ class BaseAgentRunner:
 
     def setup_session(
         self,
-        session_id: Optional[str] = None,
-        initial_history: Optional[list] = None,
+        session_id: str | None = None,
+        initial_history: list | None = None,
     ) -> AgentSession:
         """Setup session for agent execution.
 
@@ -85,6 +95,7 @@ class BaseAgentRunner:
         """
         if session_id is None:
             import uuid
+
             session_id = str(uuid.uuid4())
 
         return AgentSession(session_id=session_id, initial_history=initial_history)
@@ -93,9 +104,9 @@ class BaseAgentRunner:
         self,
         agent_name: str,
         context: Any,
-        model_override: Optional[str] = None,
-        model_settings_override: Optional["ModelSettings"] = None,
-        capabilities: Optional[List[Capability]] = None,
+        model_override: str | None = None,
+        model_settings_override: ModelSettings | None = None,
+        capabilities: list[Capability] | None = None,
     ) -> Agent:
         """Create an agent instance with proper tools and configuration.
 
@@ -166,15 +177,15 @@ class BaseAgentRunner:
         context: Any,
         session: AgentSession,
         streaming: bool = False,
-        on_event: Optional[Callable] = None,
+        on_event: Callable | None = None,
         fallback_on_overflow: bool = False,
-        fallback_prompt_builder: Optional[Callable] = None,
+        fallback_prompt_builder: Callable | None = None,
         max_turns: int = 10,
         input_text: str = "",
-        turn_budget: Optional[TurnBudget] = None,
-        error_recovery: Optional[ToolErrorRecovery] = None,
-        model_override: Optional[str] = None,
-        model_settings_override: Optional["ModelSettings"] = None,
+        turn_budget: TurnBudget | None = None,
+        error_recovery: ToolErrorRecovery | None = None,
+        model_override: str | None = None,
+        model_settings_override: ModelSettings | None = None,
     ) -> Any:
         """Run an agent and return its final_output directly.
 
@@ -233,14 +244,23 @@ class BaseAgentRunner:
 
         if streaming:
             return await self._execute_streamed(
-                agent_name, context, session, on_event, sdk_max_turns, input_text,
+                agent_name,
+                context,
+                session,
+                on_event,
+                sdk_max_turns,
+                input_text,
                 capabilities=capabilities,
                 model_override=model_override,
                 model_settings_override=model_settings_override,
             )
         elif fallback_on_overflow:
             return await self._execute_with_fallback(
-                agent_name, context, session, sdk_max_turns, input_text,
+                agent_name,
+                context,
+                session,
+                sdk_max_turns,
+                input_text,
                 fallback_prompt_builder,
                 capabilities=capabilities,
                 model_override=model_override,
@@ -248,7 +268,11 @@ class BaseAgentRunner:
             )
         else:
             return await self._execute_basic(
-                agent_name, context, session, sdk_max_turns, input_text,
+                agent_name,
+                context,
+                session,
+                sdk_max_turns,
+                input_text,
                 capabilities=capabilities,
                 model_override=model_override,
                 model_settings_override=model_settings_override,
@@ -261,14 +285,15 @@ class BaseAgentRunner:
         session: AgentSession,
         max_turns: int,
         input_text: str,
-        capabilities: Optional[List[Capability]] = None,
-        model_override: Optional[str] = None,
-        model_settings_override: Optional["ModelSettings"] = None,
+        capabilities: list[Capability] | None = None,
+        model_override: str | None = None,
+        model_settings_override: ModelSettings | None = None,
     ) -> Any:
         """Run agent via Runner.run() and return final_output."""
         capabilities = capabilities or []
         agent = await self.create_agent(
-            agent_name=agent_name, context=context,
+            agent_name=agent_name,
+            context=context,
             model_override=model_override,
             model_settings_override=model_settings_override,
             capabilities=capabilities,
@@ -278,7 +303,7 @@ class BaseAgentRunner:
 
         logger.info(f"Running agent: {agent_name}")
 
-        run_kwargs: Dict[str, Any] = {
+        run_kwargs: dict[str, Any] = {
             "starting_agent": agent,
             "input": input_text,
             "session": session,
@@ -303,10 +328,10 @@ class BaseAgentRunner:
         session: AgentSession,
         max_turns: int,
         input_text: str,
-        fallback_prompt_builder: Optional[Callable],
-        capabilities: Optional[List[Capability]] = None,
-        model_override: Optional[str] = None,
-        model_settings_override: Optional["ModelSettings"] = None,
+        fallback_prompt_builder: Callable | None,
+        capabilities: list[Capability] | None = None,
+        model_override: str | None = None,
+        model_settings_override: ModelSettings | None = None,
     ) -> Any:
         """Run agent with automatic fallback on context overflow.
 
@@ -316,7 +341,8 @@ class BaseAgentRunner:
         capabilities = capabilities or []
         agent_def = self._get_agent_definition(agent_name)
         agent = await self.create_agent(
-            agent_name=agent_name, context=context,
+            agent_name=agent_name,
+            context=context,
             model_override=model_override,
             model_settings_override=model_settings_override,
             capabilities=capabilities,
@@ -339,10 +365,7 @@ class BaseAgentRunner:
 
         except Exception as err:
             err_str = str(err)
-            is_recoverable = (
-                "Max turns" in err_str
-                or "context_length_exceeded" in err_str
-            )
+            is_recoverable = "Max turns" in err_str or "context_length_exceeded" in err_str
             if not is_recoverable:
                 raise
 
@@ -357,14 +380,14 @@ class BaseAgentRunner:
             builder = fallback_prompt_builder or self._default_fallback_prompt_builder
             prompt = builder(instructions, collecting.raw_items, agent_def)
 
-            from openai import AsyncOpenAI
             from agents.models._openai_shared import get_default_openai_key
+            from openai import AsyncOpenAI
 
             api_key = get_default_openai_key()
             client = AsyncOpenAI(api_key=api_key)
 
             output_type = self._resolve_output_type(agent_def.output_dataclass)
-            use_json = output_type and output_type != str
+            use_json = output_type and output_type is not str
 
             # Reuse or build the SDK's AgentOutputSchema so the fallback
             # LLM sees the identical JSON schema (including the "response"
@@ -372,17 +395,19 @@ class BaseAgentRunner:
             output_schema = None
             if use_json:
                 from agents.agent_output import AgentOutputSchema, AgentOutputSchemaBase
+
                 if isinstance(output_type, AgentOutputSchemaBase):
                     output_schema = output_type
                 else:
                     output_schema = AgentOutputSchema(
-                        output_type, strict_json_schema=False,
+                        output_type,
+                        strict_json_schema=False,
                     )
 
-            messages: list[Dict[str, str]] = []
+            messages: list[dict[str, str]] = []
             messages.append({"role": "user", "content": prompt})
 
-            kwargs: Dict[str, Any] = {
+            kwargs: dict[str, Any] = {
                 "model": model_override or agent_def.model or "gpt-4o-mini",
                 "messages": messages,
                 "temperature": 0.3,
@@ -426,12 +451,12 @@ class BaseAgentRunner:
         agent_name: str,
         context: Any,
         session: AgentSession,
-        on_event: Optional[Callable],
+        on_event: Callable | None,
         max_turns: int,
         input_text: str,
-        capabilities: Optional[List[Capability]] = None,
-        model_override: Optional[str] = None,
-        model_settings_override: Optional["ModelSettings"] = None,
+        capabilities: list[Capability] | None = None,
+        model_override: str | None = None,
+        model_settings_override: ModelSettings | None = None,
     ) -> Any:
         """Run agent with token-level streaming via Runner.run_streamed().
 
@@ -440,7 +465,8 @@ class BaseAgentRunner:
         """
         capabilities = capabilities or []
         agent = await self.create_agent(
-            agent_name=agent_name, context=context,
+            agent_name=agent_name,
+            context=context,
             model_override=model_override,
             model_settings_override=model_settings_override,
             capabilities=capabilities,
@@ -454,7 +480,7 @@ class BaseAgentRunner:
 
         logger.info(f"Running agent (streamed): {agent_name}")
 
-        run_kwargs: Dict[str, Any] = {
+        run_kwargs: dict[str, Any] = {
             "starting_agent": agent,
             "input": history,
             "context": context,
@@ -467,7 +493,7 @@ class BaseAgentRunner:
 
         result = Runner.run_streamed(**run_kwargs)
 
-        tools_called: List[str] = []
+        tools_called: list[str] = []
 
         total_input_tokens = 0
         total_output_tokens = 0
@@ -491,39 +517,43 @@ class BaseAgentRunner:
                 item = event.item
                 if item.type == "tool_call_item":
                     raw = getattr(item, "raw_item", None)
-                    name = (
-                        getattr(item, "name", None)
-                        or getattr(raw, "name", None)
-                        or "unknown"
-                    )
+                    name = getattr(item, "name", None) or getattr(raw, "name", None) or "unknown"
                     tools_called.append(name)
                     if on_event:
-                        on_event({
-                            "event": "tool_call",
-                            "data": {
-                                "tool": name,
-                                "message": f"Calling {name.replace('_', ' ')}...",
-                            },
-                        })
+                        on_event(
+                            {
+                                "event": "tool_call",
+                                "data": {
+                                    "tool": name,
+                                    "message": f"Calling {name.replace('_', ' ')}...",
+                                },
+                            }
+                        )
                 elif item.type == "tool_call_output_item":
                     if on_event:
-                        on_event({
-                            "event": "tool_output",
-                            "data": {"output": str(item.output)[:500]},
-                        })
+                        on_event(
+                            {
+                                "event": "tool_output",
+                                "data": {"output": str(item.output)[:500]},
+                            }
+                        )
                 elif item.type == "message_output_item":
                     if on_event:
-                        on_event({
-                            "event": "message_output",
-                            "data": {"text": ItemHelpers.text_message_output(item)},
-                        })
+                        on_event(
+                            {
+                                "event": "message_output",
+                                "data": {"text": ItemHelpers.text_message_output(item)},
+                            }
+                        )
 
             elif event.type == "agent_updated_stream_event":
                 if on_event:
-                    on_event({
-                        "event": "agent_updated",
-                        "data": {"agent": event.new_agent.name},
-                    })
+                    on_event(
+                        {
+                            "event": "agent_updated",
+                            "data": {"agent": event.new_agent.name},
+                        }
+                    )
 
         response = result.final_output
         await session.add_items([{"role": "assistant", "content": response}])
@@ -540,10 +570,12 @@ class BaseAgentRunner:
         self.last_usage = usage
 
         if on_event:
-            on_event({
-                "event": "answer",
-                "data": {"response": response, "tools_called": tools_called, "usage": usage},
-            })
+            on_event(
+                {
+                    "event": "answer",
+                    "data": {"response": response, "tools_called": tools_called, "usage": usage},
+                }
+            )
 
         logger.info(f"Agent '{agent_name}' (streamed) completed, {len(tools_called)} tool calls")
         return response
@@ -553,7 +585,7 @@ class BaseAgentRunner:
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    def _build_usage_dict(usage: Usage) -> Dict[str, Any]:
+    def _build_usage_dict(usage: Usage) -> dict[str, Any]:
         """Convert a Usage object to a plain dict."""
         return {
             "requests": usage.requests,
@@ -569,7 +601,7 @@ class BaseAgentRunner:
         }
 
     @staticmethod
-    def _aggregate_usage(result: Any) -> Dict[str, Any]:
+    def _aggregate_usage(result: Any) -> dict[str, Any]:
         """Aggregate token usage from a non-streaming RunResult."""
         usage = Usage()
         try:
@@ -588,7 +620,7 @@ class BaseAgentRunner:
         session: AgentSession,
         context: Any,
         input_message: str = "",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Run agent and return structured output with token usage.
 
         .. deprecated::
@@ -647,8 +679,7 @@ class BaseAgentRunner:
         if not agent_def:
             available = self.agent_registry.list_all()
             raise ValueError(
-                f"Agent '{agent_name}' not found in registry. "
-                f"Available agents: {available}"
+                f"Agent '{agent_name}' not found in registry. " f"Available agents: {available}"
             )
         return agent_def
 
@@ -688,7 +719,7 @@ class BaseAgentRunner:
                     context=context,
                 )
                 agent_def = self.agent_registry._agents[tool_name]
-                as_tool_kwargs: Dict[str, Any] = {
+                as_tool_kwargs: dict[str, Any] = {
                     "tool_name": tool_name,
                     "tool_description": agent_def.description,
                     "failure_error_function": structured_tool_error,
@@ -699,7 +730,7 @@ class BaseAgentRunner:
                 budget = agent_def.as_tool_turn_budget
                 if budget:
                     budget.reset()
-                    sub_caps: List[Capability] = [budget]
+                    sub_caps: list[Capability] = [budget]
                     self._apply_dynamic_instructions(tool_agent, sub_caps)
                     tool_agent.tools.append(request_extension_tool)
                     as_tool_kwargs["hooks"] = _CompositeHooks(sub_caps)
@@ -834,7 +865,7 @@ class BaseAgentRunner:
         handoffs: list,
         output_type,
         model_settings,
-        model_override: Optional[str] = None,
+        model_override: str | None = None,
     ) -> dict:
         """Build agent constructor kwargs.
 
@@ -875,10 +906,10 @@ class BaseAgentRunner:
     @staticmethod
     def _build_run_capabilities(
         agent_def: Any,
-        turn_budget: Optional[TurnBudget],
-        error_recovery: Optional[ToolErrorRecovery],
-        on_event: Optional[Callable],
-    ) -> List[Capability]:
+        turn_budget: TurnBudget | None,
+        error_recovery: ToolErrorRecovery | None,
+        on_event: Callable | None,
+    ) -> list[Capability]:
         """Compose the effective capability list for one ``execute()`` call.
 
         Declarative capabilities (``agent_def.capabilities``) are cloned for
@@ -886,7 +917,7 @@ class BaseAgentRunner:
         inspect their state after the run. Every effective capability is
         reset and gets ``on_event`` wired through.
         """
-        effective: List[Capability] = []
+        effective: list[Capability] = []
 
         for cap in agent_def.capabilities:
             clone = cap.clone()
@@ -906,7 +937,7 @@ class BaseAgentRunner:
     @staticmethod
     def _apply_dynamic_instructions(
         agent: Agent,
-        capabilities: List[Capability],
+        capabilities: list[Capability],
     ) -> None:
         """Wrap agent.instructions to merge in capability fragments per turn.
 
@@ -936,8 +967,8 @@ class BaseAgentRunner:
 
     @staticmethod
     def _build_hooks(
-        capabilities: List[Capability],
-    ) -> Optional[RunHooks]:
+        capabilities: list[Capability],
+    ) -> RunHooks | None:
         """Wrap capabilities in a single RunHooks adapter, or None when empty."""
         if not capabilities:
             return None
@@ -950,7 +981,7 @@ class BaseAgentRunner:
     @staticmethod
     def _default_fallback_prompt_builder(
         instructions: str,
-        raw_items: List[Dict[str, Any]],
+        raw_items: list[dict[str, Any]],
         agent_def: Any,
     ) -> str:
         """Default fallback prompt: concatenate instructions + tool outputs.
@@ -976,8 +1007,7 @@ class BaseAgentRunner:
                 tool_outputs.append(str(output)[:2000])
 
         context_str = (
-            "\n\n---\n\n".join(tool_outputs) if tool_outputs
-            else "(no tool outputs collected)"
+            "\n\n---\n\n".join(tool_outputs) if tool_outputs else "(no tool outputs collected)"
         )
         return (
             f"{instructions}\n\n"
@@ -996,7 +1026,7 @@ class _CollectingSessionWrapper:
 
     def __init__(self, real_session: AgentSession) -> None:
         self._real = real_session
-        self.raw_items: List[Dict[str, Any]] = []
+        self.raw_items: list[dict[str, Any]] = []
 
     @property
     def session_id(self) -> str:
@@ -1014,7 +1044,7 @@ class _CollectingSessionWrapper:
     def session_settings(self, value) -> None:
         self._real.session_settings = value
 
-    async def get_items(self, limit: Optional[int] = None) -> list:
+    async def get_items(self, limit: int | None = None) -> list:
         return await self._real.get_items(limit)
 
     async def add_items(self, items: list) -> None:
@@ -1037,7 +1067,7 @@ class _CollectingSessionWrapper:
 def _merge_capability_instructions(
     base: str,
     ctx_wrapper: RunContextWrapper,
-    capabilities: List[Capability],
+    capabilities: list[Capability],
 ) -> str:
     """Append each capability's current instruction fragment to base."""
     parts = [base]
@@ -1057,7 +1087,7 @@ class _CompositeHooks(RunHooks):
     receives them directly.
     """
 
-    def __init__(self, capabilities: List[Capability]) -> None:
+    def __init__(self, capabilities: list[Capability]) -> None:
         self._capabilities = capabilities
 
     async def on_agent_start(self, context, agent):

--- a/sinan_agentic_core/core/base_runner.py
+++ b/sinan_agentic_core/core/base_runner.py
@@ -20,11 +20,13 @@ from agents import (
     Runner,
     Usage,
 )
+from agents.items import TResponseInputItem
 from openai.types.responses import ResponseCompletedEvent, ResponseTextDeltaEvent
 
 from ..models import outputs as output_models
 from ..models.context import AgentContext
 from ..registry import get_agent_registry, get_guardrail_registry, get_tool_registry
+from ..registry.agent_registry import AgentDefinition
 from ..session import AgentSession, ConversationHistory
 from .capabilities import Capability
 from .errors import structured_tool_error
@@ -142,6 +144,7 @@ class BaseAgentRunner:
         handoffs = await self._build_handoffs(agent_def.handoffs, context)
         output_type = self._resolve_output_type(agent_def.output_dataclass)
 
+        model_settings: ModelSettings | None
         if model_settings_override is not None:
             model_settings = model_settings_override
         else:
@@ -670,7 +673,7 @@ class BaseAgentRunner:
     # Private helpers — agent construction
     # ------------------------------------------------------------------ #
 
-    def _get_agent_definition(self, agent_name: str) -> Any:
+    def _get_agent_definition(self, agent_name: str) -> AgentDefinition:
         """Get agent definition from registry with validation.
 
         Args:
@@ -823,7 +826,7 @@ class BaseAgentRunner:
 
         return handoffs
 
-    def _resolve_output_type(self, output_dataclass: Any) -> Any:
+    def _resolve_output_type(self, output_dataclass: Any) -> type[Any]:
         """Resolve output type from agent definition.
 
         Args:
@@ -837,14 +840,18 @@ class BaseAgentRunner:
 
         if isinstance(output_dataclass, str):
             try:
-                return getattr(output_models, output_dataclass)
+                resolved: type[Any] = getattr(output_models, output_dataclass)
+                return resolved
             except AttributeError:
                 logger.warning(f"Output dataclass '{output_dataclass}' not found")
                 return str
 
-        return output_dataclass
+        cls: type[Any] = output_dataclass
+        return cls
 
-    def _build_model_settings(self, agent_def: Any, ctx_wrapper: RunContextWrapper[Any]) -> Any:
+    def _build_model_settings(
+        self, agent_def: Any, ctx_wrapper: RunContextWrapper[Any]
+    ) -> ModelSettings | None:
         """Build model settings if provided.
 
         Args:
@@ -858,7 +865,8 @@ class BaseAgentRunner:
             return None
 
         try:
-            return agent_def.model_settings_fn(ctx_wrapper)
+            settings: ModelSettings | None = agent_def.model_settings_fn(ctx_wrapper)
+            return settings
         except Exception as e:
             logger.error(f"Error building model settings: {e}")
             return None
@@ -1064,7 +1072,7 @@ class _CollectingSessionWrapper:
         self.raw_items.extend(items)
         await self._real.add_items(items)
 
-    async def pop_item(self) -> Any:
+    async def pop_item(self) -> "TResponseInputItem | None":
         return await self._real.pop_item()
 
     async def clear_session(self) -> None:

--- a/sinan_agentic_core/core/base_runner.py
+++ b/sinan_agentic_core/core/base_runner.py
@@ -25,7 +25,7 @@ from openai.types.responses import ResponseCompletedEvent, ResponseTextDeltaEven
 from ..models import outputs as output_models
 from ..models.context import AgentContext
 from ..registry import get_agent_registry, get_guardrail_registry, get_tool_registry
-from ..session import AgentSession
+from ..session import AgentSession, ConversationHistory
 from .capabilities import Capability
 from .errors import structured_tool_error
 from .tool_error_recovery import ToolErrorRecovery
@@ -47,7 +47,7 @@ class BaseAgentRunner:
     - Streaming: Runner.run_streamed() with event callbacks -> returns final_output
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize registries and build tool/guardrail mappings."""
         self.agent_registry = get_agent_registry()
         self.tool_registry = get_tool_registry()
@@ -68,7 +68,7 @@ class BaseAgentRunner:
             f"Loaded {len(self.guardrail_map)} guardrails: {list(self.guardrail_map.keys())}"
         )
 
-    def setup_context(self, **context_data) -> AgentContext:
+    def setup_context(self, **context_data: Any) -> AgentContext:
         """Setup context with provided data.
 
         Args:
@@ -82,7 +82,7 @@ class BaseAgentRunner:
     def setup_session(
         self,
         session_id: str | None = None,
-        initial_history: list | None = None,
+        initial_history: list[Any] | None = None,
     ) -> AgentSession:
         """Setup session for agent execution.
 
@@ -98,7 +98,12 @@ class BaseAgentRunner:
 
             session_id = str(uuid.uuid4())
 
-        return AgentSession(session_id=session_id, initial_history=initial_history)
+        history: ConversationHistory | None = None
+        if initial_history:
+            history = ConversationHistory()
+            history.messages = list(initial_history)
+
+        return AgentSession(session_id=session_id, initial_history=history)
 
     async def create_agent(
         self,
@@ -177,13 +182,13 @@ class BaseAgentRunner:
         context: Any,
         session: AgentSession,
         streaming: bool = False,
-        on_event: Callable | None = None,
+        on_event: Callable[..., Any] | None = None,
         fallback_on_overflow: bool = False,
-        fallback_prompt_builder: Callable | None = None,
+        fallback_prompt_builder: Callable[..., Any] | None = None,
         max_turns: int = 10,
         input_text: str = "",
         turn_budget: TurnBudget | None = None,
-        error_recovery: ToolErrorRecovery | None = None,
+        error_recovery: ToolErrorRecovery | bool | None = None,
         model_override: str | None = None,
         model_settings_override: ModelSettings | None = None,
     ) -> Any:
@@ -224,6 +229,8 @@ class BaseAgentRunner:
         # Auto-create error recovery if True was passed
         if error_recovery is True:
             error_recovery = ToolErrorRecovery(tool_registry=self.tool_registry)
+        elif error_recovery is False:
+            error_recovery = None
 
         capabilities = self._build_run_capabilities(
             agent_def=agent_def,
@@ -328,7 +335,7 @@ class BaseAgentRunner:
         session: AgentSession,
         max_turns: int,
         input_text: str,
-        fallback_prompt_builder: Callable | None,
+        fallback_prompt_builder: Callable[..., Any] | None,
         capabilities: list[Capability] | None = None,
         model_override: str | None = None,
         model_settings_override: ModelSettings | None = None,
@@ -451,7 +458,7 @@ class BaseAgentRunner:
         agent_name: str,
         context: Any,
         session: AgentSession,
-        on_event: Callable | None,
+        on_event: Callable[..., Any] | None,
         max_turns: int,
         input_text: str,
         capabilities: list[Capability] | None = None,
@@ -663,7 +670,7 @@ class BaseAgentRunner:
     # Private helpers — agent construction
     # ------------------------------------------------------------------ #
 
-    def _get_agent_definition(self, agent_name: str):
+    def _get_agent_definition(self, agent_name: str) -> Any:
         """Get agent definition from registry with validation.
 
         Args:
@@ -683,7 +690,7 @@ class BaseAgentRunner:
             )
         return agent_def
 
-    def _build_instructions(self, agent_def, ctx_wrapper: RunContextWrapper) -> str:
+    def _build_instructions(self, agent_def: Any, ctx_wrapper: RunContextWrapper[Any]) -> str:
         """Build agent instructions, handling both static and dynamic.
 
         Args:
@@ -696,9 +703,9 @@ class BaseAgentRunner:
         instructions = agent_def.instructions
         if callable(instructions):
             instructions = instructions(ctx_wrapper, agent_def)
-        return instructions
+        return str(instructions)
 
-    async def _build_tools(self, tool_names: list, context: Any) -> list:
+    async def _build_tools(self, tool_names: list[str], context: Any) -> list[Any]:
         """Build agent tools list, handling regular tools and agents-as-tools.
 
         Args:
@@ -708,7 +715,7 @@ class BaseAgentRunner:
         Returns:
             List of configured tool functions
         """
-        agent_tools = []
+        agent_tools: list[Any] = []
 
         for tool_name in tool_names:
             if tool_name in self.tool_map:
@@ -744,7 +751,7 @@ class BaseAgentRunner:
 
         return agent_tools
 
-    def _build_hosted_tools(self, hosted_tools: list) -> list:
+    def _build_hosted_tools(self, hosted_tools: list[Any]) -> list[Any]:
         """Build hosted tools list (e.g., WebSearchTool, FileSearchTool).
 
         Hosted tools are OpenAI SDK tools that run on LLM servers alongside
@@ -757,7 +764,7 @@ class BaseAgentRunner:
         Returns:
             List of hosted tool instances
         """
-        tools = []
+        tools: list[Any] = []
 
         for tool_factory in hosted_tools:
             try:
@@ -773,7 +780,7 @@ class BaseAgentRunner:
 
         return tools
 
-    def _build_guardrails(self, guardrail_names: list) -> list:
+    def _build_guardrails(self, guardrail_names: list[str]) -> list[Any]:
         """Build agent guardrails list.
 
         Args:
@@ -782,7 +789,7 @@ class BaseAgentRunner:
         Returns:
             List of configured guardrail functions
         """
-        agent_guardrails = []
+        agent_guardrails: list[Any] = []
 
         for guardrail_name in guardrail_names:
             if guardrail_name in self.guardrail_map:
@@ -792,7 +799,7 @@ class BaseAgentRunner:
 
         return agent_guardrails
 
-    async def _build_handoffs(self, handoff_names: list, context: Any) -> list:
+    async def _build_handoffs(self, handoff_names: list[str], context: Any) -> list[Any]:
         """Build agent handoffs list.
 
         Args:
@@ -802,7 +809,7 @@ class BaseAgentRunner:
         Returns:
             List of configured handoff agent instances
         """
-        handoffs = []
+        handoffs: list[Any] = []
 
         for handoff_name in handoff_names:
             if handoff_name in self.agent_registry._agents:
@@ -816,7 +823,7 @@ class BaseAgentRunner:
 
         return handoffs
 
-    def _resolve_output_type(self, output_dataclass):
+    def _resolve_output_type(self, output_dataclass: Any) -> Any:
         """Resolve output type from agent definition.
 
         Args:
@@ -837,7 +844,7 @@ class BaseAgentRunner:
 
         return output_dataclass
 
-    def _build_model_settings(self, agent_def, ctx_wrapper: RunContextWrapper):
+    def _build_model_settings(self, agent_def: Any, ctx_wrapper: RunContextWrapper[Any]) -> Any:
         """Build model settings if provided.
 
         Args:
@@ -858,15 +865,15 @@ class BaseAgentRunner:
 
     def _build_agent_kwargs(
         self,
-        agent_def,
+        agent_def: Any,
         instructions: str,
-        tools: list,
-        guardrails: list,
-        handoffs: list,
-        output_type,
-        model_settings,
+        tools: list[Any],
+        guardrails: list[Any],
+        handoffs: list[Any],
+        output_type: Any,
+        model_settings: Any,
         model_override: str | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Build agent constructor kwargs.
 
         Args:
@@ -882,7 +889,7 @@ class BaseAgentRunner:
         Returns:
             Dictionary of agent constructor arguments
         """
-        agent_kwargs = {
+        agent_kwargs: dict[str, Any] = {
             "name": agent_def.name,
             "instructions": instructions,
             "tools": tools,
@@ -908,7 +915,7 @@ class BaseAgentRunner:
         agent_def: Any,
         turn_budget: TurnBudget | None,
         error_recovery: ToolErrorRecovery | None,
-        on_event: Callable | None,
+        on_event: Callable[..., Any] | None,
     ) -> list[Capability]:
         """Compose the effective capability list for one ``execute()`` call.
 
@@ -952,15 +959,21 @@ class BaseAgentRunner:
         if callable(base_instructions):
             original_fn = base_instructions
 
-            def dynamic_instructions(ctx_wrapper, agent_obj):
+            def dynamic_instructions(
+                ctx_wrapper: RunContextWrapper[Any], agent_obj: Agent[Any]
+            ) -> str:
                 base = original_fn(ctx_wrapper, agent_obj)
+                if not isinstance(base, str):
+                    base = str(base)
                 return _merge_capability_instructions(base, ctx_wrapper, capabilities)
 
             agent.instructions = dynamic_instructions
         else:
             static_text = base_instructions or ""
 
-            def dynamic_from_static(ctx_wrapper, agent_obj):
+            def dynamic_from_static(
+                ctx_wrapper: RunContextWrapper[Any], agent_obj: Agent[Any]
+            ) -> str:
                 return _merge_capability_instructions(static_text, ctx_wrapper, capabilities)
 
             agent.instructions = dynamic_from_static
@@ -1037,21 +1050,21 @@ class _CollectingSessionWrapper:
         self._real.session_id = value
 
     @property
-    def session_settings(self):
+    def session_settings(self) -> Any:
         return getattr(self._real, "session_settings", None)
 
     @session_settings.setter
-    def session_settings(self, value) -> None:
+    def session_settings(self, value: Any) -> None:
         self._real.session_settings = value
 
-    async def get_items(self, limit: int | None = None) -> list:
+    async def get_items(self, limit: int | None = None) -> list[Any]:
         return await self._real.get_items(limit)
 
-    async def add_items(self, items: list) -> None:
+    async def add_items(self, items: list[Any]) -> None:
         self.raw_items.extend(items)
         await self._real.add_items(items)
 
-    async def pop_item(self):
+    async def pop_item(self) -> Any:
         return await self._real.pop_item()
 
     async def clear_session(self) -> None:
@@ -1066,7 +1079,7 @@ class _CollectingSessionWrapper:
 
 def _merge_capability_instructions(
     base: str,
-    ctx_wrapper: RunContextWrapper,
+    ctx_wrapper: RunContextWrapper[Any],
     capabilities: list[Capability],
 ) -> str:
     """Append each capability's current instruction fragment to base."""
@@ -1090,31 +1103,33 @@ class _CompositeHooks(RunHooks):
     def __init__(self, capabilities: list[Capability]) -> None:
         self._capabilities = capabilities
 
-    async def on_agent_start(self, context, agent):
+    async def on_agent_start(self, context: Any, agent: Any) -> None:
         for cap in self._capabilities:
             cap.on_agent_start(context, agent)
 
-    async def on_agent_end(self, context, agent, output):
+    async def on_agent_end(self, context: Any, agent: Any, output: Any) -> None:
         for cap in self._capabilities:
             cap.on_agent_end(context, agent, output)
 
-    async def on_handoff(self, context, from_agent, to_agent):
+    async def on_handoff(self, context: Any, from_agent: Any, to_agent: Any) -> None:
         for cap in self._capabilities:
             cap.on_handoff(context, from_agent, to_agent)
 
-    async def on_tool_start(self, context, agent, tool):
+    async def on_tool_start(self, context: Any, agent: Any, tool: Any) -> None:
         args = getattr(context, "tool_arguments", "")
         for cap in self._capabilities:
             cap.on_tool_start(context, tool, args)
 
-    async def on_tool_end(self, context, agent, tool, result):
+    async def on_tool_end(self, context: Any, agent: Any, tool: Any, result: Any) -> None:
         for cap in self._capabilities:
             cap.on_tool_end(context, tool, result)
 
-    async def on_llm_start(self, context, agent, system_prompt, input_items):
+    async def on_llm_start(
+        self, context: Any, agent: Any, system_prompt: Any, input_items: Any
+    ) -> None:
         for cap in self._capabilities:
             cap.on_llm_start(context, agent, system_prompt, input_items)
 
-    async def on_llm_end(self, context, agent, response):
+    async def on_llm_end(self, context: Any, agent: Any, response: Any) -> None:
         for cap in self._capabilities:
             cap.on_llm_end(context, agent, response)

--- a/sinan_agentic_core/core/capabilities/base.py
+++ b/sinan_agentic_core/core/capabilities/base.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any
 
 from agents import RunContextWrapper, Tool
 
@@ -41,7 +41,7 @@ class Capability:
     when streaming.
     """
 
-    on_event: Optional[Callable[[dict[str, Any]], None]] = None
+    on_event: Callable[[dict[str, Any]], None] | None = None
 
     def instructions(self, ctx: RunContextWrapper[Any]) -> str | None:
         """Contribute a fragment to the system prompt for the next turn.
@@ -100,7 +100,7 @@ class Capability:
         self,
         ctx: RunContextWrapper[Any],
         agent: Any,
-        system_prompt: Optional[str],
+        system_prompt: str | None,
         input_items: Any,
     ) -> None:
         """Called immediately before the model is invoked for a turn."""

--- a/sinan_agentic_core/core/tool_error_recovery.py
+++ b/sinan_agentic_core/core/tool_error_recovery.py
@@ -207,8 +207,7 @@ class ToolErrorRecovery(Capability):
     def has_critical_errors(self) -> bool:
         """True if any tool has hit the identical-retry stop threshold."""
         return any(
-            e.identical_count >= self.max_identical_before_stop
-            for e in self._errors.values()
+            e.identical_count >= self.max_identical_before_stop for e in self._errors.values()
         )
 
     def get_error_summary(self) -> dict[str, Any]:
@@ -253,10 +252,12 @@ class ToolErrorRecovery(Capability):
         arguments = self._pending_args.pop(tool_name, "")
         self.record_tool_result(tool_name, result, arguments)
         if self.on_event and self.has_errors:
-            self.on_event({
-                "event": "tool_error_recovery",
-                "data": self.get_error_summary(),
-            })
+            self.on_event(
+                {
+                    "event": "tool_error_recovery",
+                    "data": self.get_error_summary(),
+                }
+            )
 
     def clone(self) -> "ToolErrorRecovery":
         """Return a fresh ``ToolErrorRecovery`` with the same configuration and zeroed state."""
@@ -307,9 +308,7 @@ class ToolErrorRecovery(Capability):
                 )
         raw_last = data.get("last_args", {})
         self._last_args = (
-            {str(k): str(v) for k, v in raw_last.items()}
-            if isinstance(raw_last, dict)
-            else {}
+            {str(k): str(v) for k, v in raw_last.items()} if isinstance(raw_last, dict) else {}
         )
         self._pending_args = {}
 
@@ -320,7 +319,7 @@ class ToolErrorRecovery(Capability):
     def _section_first(self, entry: ToolErrorEntry) -> str:
         """First failure: show error and hint."""
         args_info = f" (called with: {entry.last_args_summary})" if entry.last_args_summary else ""
-        line = f"- {entry.tool_name} returned error: \"{entry.error}\"{args_info}"
+        line = f'- {entry.tool_name} returned error: "{entry.error}"{args_info}'
         if entry.recovery_hint:
             line += f"\n  Recovery hint: {entry.recovery_hint}"
         return line
@@ -329,7 +328,7 @@ class ToolErrorRecovery(Capability):
         """Repeated failure with same args: warn strongly."""
         line = (
             f"- {entry.tool_name} has FAILED {entry.identical_count} TIMES "
-            f"with identical arguments. Error: \"{entry.error}\"\n"
+            f'with identical arguments. Error: "{entry.error}"\n'
             f"  You are repeating the same failing call. "
             f"Change your parameters or use a different tool/approach."
         )
@@ -342,7 +341,7 @@ class ToolErrorRecovery(Capability):
         return (
             f"- STOP: {entry.tool_name} has failed {entry.identical_count} times "
             f"with the same arguments. Do NOT call this tool again.\n"
-            f"  Error was: \"{entry.error}\"\n"
+            f'  Error was: "{entry.error}"\n'
             f"  Move on to your next task, try a completely different approach, "
             f"or return your partial results."
         )
@@ -412,5 +411,3 @@ class ToolErrorRecovery(Capability):
             return ", ".join(parts[:5])  # max 5 params shown
         except (json.JSONDecodeError, TypeError):
             return arguments[:80]
-
-

--- a/sinan_agentic_core/core/tool_error_recovery.py
+++ b/sinan_agentic_core/core/tool_error_recovery.py
@@ -373,7 +373,8 @@ class ToolErrorRecovery(Capability):
         if self._registry:
             tool_def = self._registry.get_tool(tool_name)
             if tool_def and getattr(tool_def, "recovery_hint", ""):
-                return tool_def.recovery_hint
+                hint: str = tool_def.recovery_hint
+                return hint
         return self._mcp_hints.get(tool_name, "")
 
     @staticmethod

--- a/sinan_agentic_core/core/turn_budget.py
+++ b/sinan_agentic_core/core/turn_budget.py
@@ -20,7 +20,7 @@ Usage:
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from agents import RunContextWrapper, Tool
 
@@ -89,8 +89,14 @@ class TurnBudget(Capability):
         """Request additional turns. Returns (success, message)."""
         if not self.can_extend:
             if self.extensions_used >= self.max_extensions:
-                return False, f"Extension denied: maximum extensions ({self.max_extensions}) reached."
-            return False, f"Extension denied: would exceed absolute maximum ({self.absolute_max} turns)."
+                return (
+                    False,
+                    f"Extension denied: maximum extensions ({self.max_extensions}) reached.",
+                )
+            return (
+                False,
+                f"Extension denied: would exceed absolute maximum ({self.absolute_max} turns).",
+            )
 
         self.extensions_used += 1
         self.extension_reasons.append(reason)
@@ -101,7 +107,10 @@ class TurnBudget(Capability):
             self.max_extensions,
             reason,
         )
-        return True, f"Extension approved. You now have {self.remaining} turns remaining (budget: {self.effective_max})."
+        return (
+            True,
+            f"Extension approved. You now have {self.remaining} turns remaining (budget: {self.effective_max}).",
+        )
 
     def record_turn(self) -> None:
         """Record that a turn was used."""
@@ -165,22 +174,24 @@ class TurnBudget(Capability):
         self,
         ctx: RunContextWrapper[Any],
         agent: Any,
-        system_prompt: Optional[str],
+        system_prompt: str | None,
         input_items: Any,
     ) -> None:
         """Capability hook — count this turn and emit a streaming event."""
         self.record_turn()
         if self.on_event:
-            self.on_event({
-                "event": "turn_budget",
-                "data": {
-                    "turns_used": self.turns_used,
-                    "effective_max": self.effective_max,
-                    "remaining": self.remaining,
-                    "extensions_used": self.extensions_used,
-                    "is_warning": self.is_warning,
-                },
-            })
+            self.on_event(
+                {
+                    "event": "turn_budget",
+                    "data": {
+                        "turns_used": self.turns_used,
+                        "effective_max": self.effective_max,
+                        "remaining": self.remaining,
+                        "extensions_used": self.extensions_used,
+                        "is_warning": self.is_warning,
+                    },
+                }
+            )
 
     def tools(self) -> list[Tool]:
         """Expose request_extension so the agent can self-extend its budget."""

--- a/sinan_agentic_core/core/turn_budget_tool.py
+++ b/sinan_agentic_core/core/turn_budget_tool.py
@@ -6,7 +6,7 @@ The agent calls it when running low on turns and needs more time.
 
 from agents import RunContextWrapper, function_tool
 
-from ..utils.tool_helpers import unwrap_context, tool_response, tool_error
+from ..utils.tool_helpers import tool_error, tool_response, unwrap_context
 
 
 @function_tool(name_override="request_extension")
@@ -27,5 +27,7 @@ async def request_extension_tool(ctx: RunContextWrapper, reason: str) -> str:
 
     success, message = budget.request_extension(reason)
     if success:
-        return tool_response({"status": "approved", "message": message, "remaining": budget.remaining})
+        return tool_response(
+            {"status": "approved", "message": message, "remaining": budget.remaining}
+        )
     return tool_error(message)

--- a/sinan_agentic_core/guardrails/__init__.py
+++ b/sinan_agentic_core/guardrails/__init__.py
@@ -5,7 +5,7 @@ Define input validation guardrails here.
 Example:
     def validate_input(ctx, input_data: dict) -> tuple[bool, str]:
         '''Validate input data.
-        
+
         Returns:
             (is_valid, error_message)
         '''

--- a/sinan_agentic_core/instructions/builder.py
+++ b/sinan_agentic_core/instructions/builder.py
@@ -86,7 +86,8 @@ class InstructionBuilder:
         budget = self._ctx_attr("_turn_budget")
         if budget is None:
             return None
-        return budget.build_instruction_section()
+        section: str = budget.build_instruction_section()
+        return section
 
     def extra_sections(self) -> list[tuple[str, str]]:
         """Additional named sections appended after the main sections.

--- a/sinan_agentic_core/instructions/builder.py
+++ b/sinan_agentic_core/instructions/builder.py
@@ -106,7 +106,15 @@ class InstructionBuilder:
         Override to reorder, add, or remove sections.
         Extra sections from extra_sections() are always appended after these.
         """
-        return ["persona", "domain_knowledge", "context_section", "steps", "rules", "output_format", "turn_budget_section"]
+        return [
+            "persona",
+            "domain_knowledge",
+            "context_section",
+            "steps",
+            "rules",
+            "output_format",
+            "turn_budget_section",
+        ]
 
     # ------------------------------------------------------------------ #
     # Assembly

--- a/sinan_agentic_core/mcp/context_protocol.py
+++ b/sinan_agentic_core/mcp/context_protocol.py
@@ -52,7 +52,7 @@ class MCPContextFactory(ABC):
         finally:
             await self.cleanup(ctx)
 
-    def get_resource_handlers(self) -> dict[str, Callable]:
+    def get_resource_handlers(self) -> dict[str, Callable[..., Any]]:
         """Return MCP resource handlers: ``{uri_pattern: async_handler}``.
 
         Override to expose app-specific resources (documents, schemas, etc.).
@@ -60,7 +60,7 @@ class MCPContextFactory(ABC):
         """
         return {}
 
-    def get_prompt_handlers(self) -> dict[str, Callable]:
+    def get_prompt_handlers(self) -> dict[str, Callable[..., Any]]:
         """Return MCP prompt handlers: ``{name: handler_fn}``.
 
         Override to expose app-specific prompt templates.

--- a/sinan_agentic_core/mcp/context_protocol.py
+++ b/sinan_agentic_core/mcp/context_protocol.py
@@ -15,8 +15,9 @@ Example::
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Callable
+from typing import Any
 
 
 class MCPContextFactory(ABC):

--- a/sinan_agentic_core/mcp/server_builder.py
+++ b/sinan_agentic_core/mcp/server_builder.py
@@ -21,11 +21,11 @@ Usage::
 import logging
 from typing import Any
 
-from ..registry.tool_catalog import ToolCatalog
+from ..registry.tool_catalog import ToolCatalog, ToolMCPConfig
 from ..registry.tool_registry import ToolRegistry
 from .context_protocol import MCPContextFactory
 from .tool_adapter import MCPToolAdapter
-from .yaml_schema import MCPServerConfig, MCPToolConfig
+from .yaml_schema import MCPServerConfig
 
 logger = logging.getLogger(__name__)
 
@@ -155,14 +155,14 @@ class MCPServerBuilder:
 
         return mcp
 
-    def _get_tool_mcp_config(self, tool_name: str) -> MCPToolConfig | None:
+    def _get_tool_mcp_config(self, tool_name: str) -> "ToolMCPConfig | None":
         """Get MCP-specific config for a tool from the catalog."""
         try:
             entry = self._catalog.get(tool_name)
         except KeyError:
             return None
 
-        mcp_raw = getattr(entry, "mcp", None)
+        mcp_raw: ToolMCPConfig | None = getattr(entry, "mcp", None)
         if mcp_raw is None:
             return None
         return mcp_raw

--- a/sinan_agentic_core/mcp/server_builder.py
+++ b/sinan_agentic_core/mcp/server_builder.py
@@ -88,8 +88,8 @@ class MCPServerBuilder:
         Returns:
             A ``FastMCP`` instance ready to run.
         """
-        FastMCP = _import_fastmcp()
-        ToolAnnotations = _import_tool_annotations()
+        FastMCP = _import_fastmcp()  # noqa: N806 — bound to a class
+        ToolAnnotations = _import_tool_annotations()  # noqa: N806 — bound to a class
 
         mcp = FastMCP(self._server_name, **self._fastmcp_kwargs)
 

--- a/sinan_agentic_core/mcp/tool_adapter.py
+++ b/sinan_agentic_core/mcp/tool_adapter.py
@@ -18,7 +18,7 @@ import inspect
 import json
 import logging
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 from ..registry.tool_registry import ToolDefinition, ToolRegistry
 from .context_protocol import MCPContextFactory
@@ -115,7 +115,7 @@ def _build_mcp_handler(
             default = inspect.Parameter.empty
         else:
             default = prop_def.get("default", None)
-            py_type = Optional[py_type]  # type: ignore[assignment]
+            py_type = py_type | None  # type: ignore[assignment]
 
         parameters.append(
             inspect.Parameter(

--- a/sinan_agentic_core/mcp/tool_adapter.py
+++ b/sinan_agentic_core/mcp/tool_adapter.py
@@ -41,7 +41,8 @@ def _get_params_schema(tool_def: ToolDefinition) -> dict[str, Any]:
 
     # Path 1: FunctionTool from OpenAI Agents SDK
     if hasattr(fn, "params_json_schema"):
-        return fn.params_json_schema
+        schema: dict[str, Any] = fn.params_json_schema
+        return schema
 
     # Path 2: raw function — build schema from type hints
     sig = inspect.signature(fn)
@@ -180,7 +181,8 @@ class MCPToolAdapter:
         impl = getattr(fn, "_impl", None)
         if impl is not None:
             async with self._context_factory.tool_context() as ctx:
-                return await impl(ctx, **params)
+                impl_result = await impl(ctx, **params)
+                return impl_result if isinstance(impl_result, str) else str(impl_result)
 
         # Path 2: FunctionTool — invoke via on_invoke_tool with synthetic context
         if _has_on_invoke_tool(fn):
@@ -189,7 +191,8 @@ class MCPToolAdapter:
         # Path 3: raw async function with ctx as first param
         if inspect.iscoroutinefunction(fn):
             async with self._context_factory.tool_context() as ctx:
-                return await fn(ctx, **params)
+                fn_result = await fn(ctx, **params)
+                return fn_result if isinstance(fn_result, str) else str(fn_result)
 
         raise RuntimeError(
             f"Tool '{tool_name}' has no supported invocation method. "

--- a/sinan_agentic_core/mcp/yaml_schema.py
+++ b/sinan_agentic_core/mcp/yaml_schema.py
@@ -29,12 +29,16 @@ from pydantic import BaseModel
 
 
 class MCPAnnotationsConfig(BaseModel):
-    """MCP tool annotations from tools.yaml."""
+    """MCP tool annotations from tools.yaml.
 
-    readOnlyHint: bool | None = None
-    openWorldHint: bool | None = None
-    destructiveHint: bool | None = None
-    idempotentHint: bool | None = None
+    Field names mirror the MCP protocol's camelCase wire format, so ruff's
+    snake_case rule (N815) is suppressed per-line.
+    """
+
+    readOnlyHint: bool | None = None  # noqa: N815 — MCP protocol field name
+    openWorldHint: bool | None = None  # noqa: N815 — MCP protocol field name
+    destructiveHint: bool | None = None  # noqa: N815 — MCP protocol field name
+    idempotentHint: bool | None = None  # noqa: N815 — MCP protocol field name
 
 
 class MCPToolConfig(BaseModel):

--- a/sinan_agentic_core/models/__init__.py
+++ b/sinan_agentic_core/models/__init__.py
@@ -1,7 +1,7 @@
 """Models package - Data models for agent system."""
 
 from .context import AgentContext
-from .outputs import ToolOutput, ChatResponse
+from .outputs import ChatResponse, ToolOutput
 
 __all__ = [
     "AgentContext",

--- a/sinan_agentic_core/models/context.py
+++ b/sinan_agentic_core/models/context.py
@@ -5,7 +5,7 @@ Replace 'database_connector' with your specific database implementation.
 """
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional, Dict, Any, List
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     # Replace with your database connector type
@@ -15,16 +15,16 @@ if TYPE_CHECKING:
 @dataclass
 class AgentContext:
     """Generic context passed to all agents.
-    
+
     This context is populated by the orchestrator as agents execute:
     - database_connector: Your database connection (Neo4j, PostgreSQL, etc.)
     - schema: Formatted schema string for agent instructions
     - query_results: Results from database queries
     - filters: User pre-selected filters/parameters
     - discovered_data: Data discovered during workflow execution
-    
+
     Extend this class for your specific use case by adding domain-specific fields.
-    
+
     Example:
         @dataclass
         class MyAppContext(AgentContext):
@@ -32,56 +32,56 @@ class AgentContext:
             workspace_id: str = ""
             custom_metadata: Dict[str, Any] = field(default_factory=dict)
     """
-    
+
     database_connector: Any  # Replace with your specific database connector type
     schema: str = ""  # Formatted schema string for agent instructions
-    schema_data: Optional[Dict[str, Any]] = None  # Raw schema data
+    schema_data: dict[str, Any] | None = None  # Raw schema data
     query_results: list[dict] = field(default_factory=list)
-    filters: Optional[Dict[str, Any]] = None  # User pre-selected filters
-    discovered_data: Dict[str, Any] = field(default_factory=dict)  # Data discovered during workflow
-    
+    filters: dict[str, Any] | None = None  # User pre-selected filters
+    discovered_data: dict[str, Any] = field(default_factory=dict)  # Data discovered during workflow
+
     @property
     def has_data(self) -> bool:
         """Check if any query results have been collected."""
         return len(self.query_results) > 0
-    
+
     def add_query_result(self, result: dict) -> None:
         """Add a database query result to the context.
-        
+
         Args:
             result: Dictionary containing query results
         """
-        if isinstance(result, dict) and 'data' in result:
-            data = result['data']
+        if isinstance(result, dict) and "data" in result:
+            data = result["data"]
             if isinstance(data, list):
                 self.query_results.extend(data)
-    
+
     def clear_results(self) -> None:
         """Clear all accumulated results."""
         self.query_results = []
         self.discovered_data = {}
-    
+
     def add_discovered_item(self, key: str, value: Any) -> None:
         """Add discovered data during workflow execution.
-        
+
         Args:
             key: Category/type of discovered data
             value: The discovered data
         """
         if key not in self.discovered_data:
             self.discovered_data[key] = []
-        
+
         if isinstance(self.discovered_data[key], list):
             self.discovered_data[key].append(value)
         else:
             self.discovered_data[key] = value
-    
+
     def get_discovered_items(self, key: str) -> Any:
         """Get discovered data by key.
-        
+
         Args:
             key: Category/type of discovered data
-            
+
         Returns:
             Discovered data or None if not found
         """

--- a/sinan_agentic_core/models/context.py
+++ b/sinan_agentic_core/models/context.py
@@ -36,7 +36,7 @@ class AgentContext:
     database_connector: Any  # Replace with your specific database connector type
     schema: str = ""  # Formatted schema string for agent instructions
     schema_data: dict[str, Any] | None = None  # Raw schema data
-    query_results: list[dict] = field(default_factory=list)
+    query_results: list[dict[str, Any]] = field(default_factory=list)
     filters: dict[str, Any] | None = None  # User pre-selected filters
     discovered_data: dict[str, Any] = field(default_factory=dict)  # Data discovered during workflow
 
@@ -45,7 +45,7 @@ class AgentContext:
         """Check if any query results have been collected."""
         return len(self.query_results) > 0
 
-    def add_query_result(self, result: dict) -> None:
+    def add_query_result(self, result: dict[str, Any]) -> None:
         """Add a database query result to the context.
 
         Args:

--- a/sinan_agentic_core/models/outputs/__init__.py
+++ b/sinan_agentic_core/models/outputs/__init__.py
@@ -28,7 +28,7 @@ class ToolOutput:
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        result = {"success": self.success}
+        result: dict[str, Any] = {"success": self.success}
         if self.data is not None:
             result["data"] = self.data
         if self.error:
@@ -60,7 +60,7 @@ class ChatResponse:
     usage: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        result = {
+        result: dict[str, Any] = {
             "success": self.success,
             "response": self.response,
             "session_id": self.session_id,

--- a/sinan_agentic_core/models/outputs/__init__.py
+++ b/sinan_agentic_core/models/outputs/__init__.py
@@ -6,7 +6,7 @@ Provides reusable dataclasses for:
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 @dataclass
@@ -21,12 +21,13 @@ class ToolOutput:
         error: Error message if success is False
         metadata: Additional context
     """
-    success: bool
-    data: Optional[Dict[str, Any]] = None
-    error: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    success: bool
+    data: dict[str, Any] | None = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
         result = {"success": self.success}
         if self.data is not None:
             result["data"] = self.data
@@ -50,14 +51,15 @@ class ChatResponse:
         usage: Token usage dict with requests, input_tokens, output_tokens,
             total_tokens, input_tokens_details, output_tokens_details
     """
+
     success: bool
     response: str = ""
     session_id: str = "default"
-    tools_called: List[str] = field(default_factory=list)
-    error: Optional[str] = None
-    usage: Optional[Dict[str, Any]] = None
+    tools_called: list[str] = field(default_factory=list)
+    error: str | None = None
+    usage: dict[str, Any] | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = {
             "success": self.success,
             "response": self.response,

--- a/sinan_agentic_core/orchestrator.py
+++ b/sinan_agentic_core/orchestrator.py
@@ -32,7 +32,7 @@ class AgentOrchestrator(BaseAgentRunner):
         )
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Initialize base class (loads registries and builds mappings)
         super().__init__()
 
@@ -41,7 +41,7 @@ class AgentOrchestrator(BaseAgentRunner):
         user_query: str,
         context_data: dict[str, Any],
         session_id: str | None = None,
-        initial_history: list | None = None,
+        initial_history: list[Any] | None = None,
         event_callback: Callable[..., Any] | None = None,
     ) -> dict[str, Any]:
         """Run the orchestrator workflow.

--- a/sinan_agentic_core/orchestrator.py
+++ b/sinan_agentic_core/orchestrator.py
@@ -5,25 +5,25 @@ Adapt this template for your specific use case.
 """
 
 import logging
-from typing import Optional, Dict, Any
+from collections.abc import Callable
+from typing import Any
 
 from .core import BaseAgentRunner
-from .services.events import StreamingHelper
 
 logger = logging.getLogger(__name__)
 
 
 class AgentOrchestrator(BaseAgentRunner):
     """Generic orchestrator using code orchestration pattern.
-    
+
     This class demonstrates the pattern of:
     1. Initialize session and context
     2. Run agents in sequence (or based on routing logic)
     3. Accumulate results in context
     4. Return final output
-    
+
     Extends BaseAgentRunner to reuse agent creation and execution logic.
-    
+
     Usage:
         orchestrator = AgentOrchestrator()
         result = await orchestrator.run_workflow(
@@ -39,11 +39,11 @@ class AgentOrchestrator(BaseAgentRunner):
     async def run_workflow(
         self,
         user_query: str,
-        context_data: Dict[str, Any],
-        session_id: Optional[str] = None,
-        initial_history: Optional[list] = None,
-        event_callback: Optional[callable] = None,
-    ) -> Dict[str, Any]:
+        context_data: dict[str, Any],
+        session_id: str | None = None,
+        initial_history: list | None = None,
+        event_callback: Callable[..., Any] | None = None,
+    ) -> dict[str, Any]:
         """Run the orchestrator workflow.
 
         Args:
@@ -59,34 +59,23 @@ class AgentOrchestrator(BaseAgentRunner):
         # 1. Setup session and context using base class methods
         session = self.setup_session(session_id=session_id, initial_history=initial_history)
         context = self.setup_context(**context_data)
-        streaming = StreamingHelper(event_callback)
 
         # Add user query to session
-        await session.add_items([{
-            "role": "user",
-            "content": user_query
-        }])
-        
+        await session.add_items([{"role": "user", "content": user_query}])
+
         try:
             # Example: Run a single agent using base class method
             result = await self.run_agent(
-                agent_name="your_agent_name",
-                session=session,
-                context=context
+                agent_name="your_agent_name", session=session, context=context
             )
-            
+
             return {
                 "success": True,
                 "result": result["output"],
                 "usage": result["usage"],
                 "session_id": session.session_id,
             }
-        
+
         except Exception as e:
             logger.error(f"Orchestration failed: {e}")
-            return {
-                "success": False,
-                "error": str(e),
-                "session_id": session.session_id
-            }
-
+            return {"success": False, "error": str(e), "session_id": session.session_id}

--- a/sinan_agentic_core/registry/__init__.py
+++ b/sinan_agentic_core/registry/__init__.py
@@ -7,9 +7,8 @@ from .agent_catalog import (
     TurnBudgetConfig,
     load_agent_catalog,
 )
-from .tool_catalog import ToolCatalog, ToolMCPConfig, ToolYamlEntry, load_tool_catalog
-from .agent_registry import AgentDefinition, AgentRegistry, get_agent_registry, register_agent
 from .agent_factory import create_agent_from_registry
+from .agent_registry import AgentDefinition, AgentRegistry, get_agent_registry, register_agent
 from .capability_registry import (
     CapabilityFactory,
     CapabilityNotFoundError,
@@ -17,17 +16,18 @@ from .capability_registry import (
     get_capability_registry,
     register_capability,
 )
-from .tool_registry import (
-    ToolRegistry,
-    get_tool_registry,
-    register_tool,
-    ToolDefinition,
-)
 from .guardrail_registry import (
+    GuardrailDefinition,
     GuardrailRegistry,
     get_guardrail_registry,
     register_guardrail,
-    GuardrailDefinition,
+)
+from .tool_catalog import ToolCatalog, ToolMCPConfig, ToolYamlEntry, load_tool_catalog
+from .tool_registry import (
+    ToolDefinition,
+    ToolRegistry,
+    get_tool_registry,
+    register_tool,
 )
 
 __all__ = [

--- a/sinan_agentic_core/registry/agent_catalog.py
+++ b/sinan_agentic_core/registry/agent_catalog.py
@@ -30,7 +30,7 @@ Usage::
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
@@ -39,6 +39,11 @@ from .capability_registry import (
     CapabilityNotFoundError,
     get_capability_registry,
 )
+
+if TYPE_CHECKING:
+    from ..core.tool_error_recovery import ToolErrorRecovery
+    from ..core.turn_budget import TurnBudget
+    from ..mcp.yaml_schema import MCPServerConfig
 
 logger = logging.getLogger(__name__)
 
@@ -189,8 +194,7 @@ def _resolve_tools(
                 if group_name not in tool_groups:
                     available = ", ".join(sorted(tool_groups.keys()))
                     raise KeyError(
-                        f"Tool group '{group_name}' not found. "
-                        f"Available: {available}"
+                        f"Tool group '{group_name}' not found. " f"Available: {available}"
                     )
                 resolved.extend(tool_groups[group_name])
             elif "tool" in item:
@@ -204,9 +208,7 @@ def _resolve_tools(
 # ---------------------------------------------------------------------------
 
 
-def _parse_capabilities(
-    agent_name: str, raw: Any
-) -> list[CapabilityRef]:
+def _parse_capabilities(agent_name: str, raw: Any) -> list[CapabilityRef]:
     """Parse the ``capabilities:`` list on an agent entry and validate names.
 
     Accepts the explicit list form documented on :class:`CapabilityRef`.
@@ -233,9 +235,7 @@ def _parse_capabilities(
                     f"Agent '{agent_name}' capabilities[{index}] is missing "
                     f"the required 'name' key."
                 )
-            ref = CapabilityRef(
-                name=item["name"], config=item.get("config", {}) or {}
-            )
+            ref = CapabilityRef(name=item["name"], config=item.get("config", {}) or {})
         else:
             raise TypeError(
                 f"Agent '{agent_name}' capabilities[{index}] must be a "
@@ -291,10 +291,7 @@ class AgentCatalog:
         """
         if name not in self._raw_agents:
             available = ", ".join(sorted(self._raw_agents.keys()))
-            raise KeyError(
-                f"Agent '{name}' not found in agents.yaml. "
-                f"Available: {available}"
-            )
+            raise KeyError(f"Agent '{name}' not found in agents.yaml. " f"Available: {available}")
         raw = self._raw_agents[name]
         raw_budget = raw.get("turn_budget")
         budget_cfg = TurnBudgetConfig(**raw_budget) if raw_budget else None
@@ -304,12 +301,8 @@ class AgentCatalog:
         return AgentYamlEntry(
             model=raw["model"],
             description=raw["description"],
-            tools=_resolve_tools(
-                raw.get("tools", []), self._tool_groups, config
-            ),
-            knowledge_text=_resolve_knowledge(
-                raw.get("knowledge", []), self._knowledge
-            ),
+            tools=_resolve_tools(raw.get("tools", []), self._tool_groups, config),
+            knowledge_text=_resolve_knowledge(raw.get("knowledge", []), self._knowledge),
             max_turns=raw.get("max_turns"),
             turn_budget=budget_cfg,
             error_recovery=raw.get("error_recovery", True),
@@ -352,36 +345,25 @@ class AgentCatalog:
         Raises:
             KeyError: If the MCP server is not defined in agents.yaml.
         """
-        from ..mcp.yaml_schema import MCPServerConfig, MCPResourceConfig, MCPPromptConfig
+        from ..mcp.yaml_schema import MCPPromptConfig, MCPResourceConfig, MCPServerConfig
 
         if name not in self._raw_mcp_servers:
             available = ", ".join(sorted(self._raw_mcp_servers.keys()))
             raise KeyError(
-                f"MCP server '{name}' not found in agents.yaml. "
-                f"Available: {available}"
+                f"MCP server '{name}' not found in agents.yaml. " f"Available: {available}"
             )
 
         raw = self._raw_mcp_servers[name]
 
         # Resolve tools (expand groups, evaluate conditions)
-        tools = _resolve_tools(
-            raw.get("tools", []), self._tool_groups, config
-        )
-        write_tools = _resolve_tools(
-            raw.get("write_tools", []), self._tool_groups, config
-        )
+        tools = _resolve_tools(raw.get("tools", []), self._tool_groups, config)
+        write_tools = _resolve_tools(raw.get("write_tools", []), self._tool_groups, config)
 
         # Parse resources
-        resources = [
-            MCPResourceConfig(**r)
-            for r in raw.get("resources", [])
-        ]
+        resources = [MCPResourceConfig(**r) for r in raw.get("resources", [])]
 
         # Parse prompts
-        prompts = [
-            MCPPromptConfig(**p)
-            for p in raw.get("prompts", [])
-        ]
+        prompts = [MCPPromptConfig(**p) for p in raw.get("prompts", [])]
 
         return MCPServerConfig(
             name=name,
@@ -465,8 +447,7 @@ def load_agent_catalog(
         import yaml
     except ImportError:
         raise ImportError(
-            "PyYAML is required for agent catalog loading. "
-            "Install it with: pip install pyyaml"
+            "PyYAML is required for agent catalog loading. " "Install it with: pip install pyyaml"
         )
 
     path = Path(path)

--- a/sinan_agentic_core/registry/agent_factory.py
+++ b/sinan_agentic_core/registry/agent_factory.py
@@ -11,7 +11,6 @@ Usage:
 """
 
 import logging
-from typing import Optional
 
 from agents import Agent
 
@@ -23,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 def create_agent_from_registry(
     agent_name: str,
-    model_override: Optional[str] = None,
+    model_override: str | None = None,
 ) -> Agent:
     """Build an Agent instance from registry definitions.
 
@@ -54,9 +53,7 @@ def create_agent_from_registry(
     agent_def = agent_registry.get(agent_name)
     if not agent_def:
         available = agent_registry.list_all()
-        raise ValueError(
-            f"Agent '{agent_name}' not found. Available: {available}"
-        )
+        raise ValueError(f"Agent '{agent_name}' not found. Available: {available}")
 
     tools = tool_registry.get_tool_functions(agent_def.tools)
 

--- a/sinan_agentic_core/registry/agent_factory.py
+++ b/sinan_agentic_core/registry/agent_factory.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import logging
+from typing import Any, cast
 
 from agents import Agent
 
@@ -61,5 +62,5 @@ def create_agent_from_registry(
         name=agent_def.name,
         instructions=agent_def.instructions,
         model=model_override or agent_def.model,
-        tools=tools,
+        tools=cast(list[Any], tools),
     )

--- a/sinan_agentic_core/registry/agent_registry.py
+++ b/sinan_agentic_core/registry/agent_registry.py
@@ -13,7 +13,7 @@ class AgentDefinition:
 
     name: str
     description: str  # Description of agent's purpose
-    instructions: str | Callable | None = None  # Static string or dynamic function
+    instructions: str | Callable[..., Any] | None = None  # Static string or dynamic function
     # Optional fields (default to empty lists)
     tools: list[str] = field(default_factory=list)  # Tool names from registry
     guardrails: list[str] = field(default_factory=list)  # Guardrail names
@@ -22,7 +22,7 @@ class AgentDefinition:
         default_factory=list
     )  # OpenAI SDK hosted tools (WebSearchTool, etc.)
     output_dataclass: Any | None = None  # Dataclass type for structured output
-    model_settings_fn: Callable | None = None  # Dynamic model settings function
+    model_settings_fn: Callable[..., Any] | None = None  # Dynamic model settings function
     capabilities: list[Capability] = field(default_factory=list)  # Pluggable agent behaviors
 
     model: str = "gpt-4o-mini"
@@ -34,7 +34,7 @@ class AgentDefinition:
     as_tool_max_turns: int | None = None  # Max turns when running as sub-agent via as_tool()
     as_tool_turn_budget: Any | None = None  # TurnBudget instance for sub-agent budget management
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Ensure instructions is provided."""
         if self.instructions is None:
             raise ValueError(f"Agent {self.name} must have instructions")
@@ -46,7 +46,7 @@ class AgentRegistry:
 
     _agents: dict[str, AgentDefinition] = field(default_factory=dict)
 
-    def register(self, agent_def: AgentDefinition):
+    def register(self, agent_def: AgentDefinition) -> None:
         """Register an agent."""
         self._agents[agent_def.name] = agent_def
 
@@ -68,6 +68,6 @@ def get_agent_registry() -> AgentRegistry:
     return _global_agent_registry
 
 
-def register_agent(agent_def: AgentDefinition):
+def register_agent(agent_def: AgentDefinition) -> None:
     """Register an agent in the global registry."""
     _global_agent_registry.register(agent_def)

--- a/sinan_agentic_core/registry/agent_registry.py
+++ b/sinan_agentic_core/registry/agent_registry.py
@@ -1,7 +1,8 @@
 """Agent Registry - Centralized definition of all agents."""
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import List, Callable, Optional, Any, Union
+from typing import Any
 
 from ..core.capabilities import Capability
 
@@ -9,24 +10,29 @@ from ..core.capabilities import Capability
 @dataclass
 class AgentDefinition:
     """Schema for an agent."""
+
     name: str
     description: str  # Description of agent's purpose
-    instructions: Optional[Union[str, Callable]] = None  # Static string or dynamic function
+    instructions: str | Callable | None = None  # Static string or dynamic function
     # Optional fields (default to empty lists)
-    tools: List[str] = field(default_factory=list)         # Tool names from registry
-    guardrails: List[str] = field(default_factory=list)    # Guardrail names
-    handoffs: List[str] = field(default_factory=list)
-    hosted_tools: List[Any] = field(default_factory=list)  # OpenAI SDK hosted tools (WebSearchTool, etc.)
-    output_dataclass: Optional[Any] = None  # Dataclass type for structured output
-    model_settings_fn: Optional[Callable] = None  # Dynamic model settings function
-    capabilities: List[Capability] = field(default_factory=list)  # Pluggable agent behaviors
+    tools: list[str] = field(default_factory=list)  # Tool names from registry
+    guardrails: list[str] = field(default_factory=list)  # Guardrail names
+    handoffs: list[str] = field(default_factory=list)
+    hosted_tools: list[Any] = field(
+        default_factory=list
+    )  # OpenAI SDK hosted tools (WebSearchTool, etc.)
+    output_dataclass: Any | None = None  # Dataclass type for structured output
+    model_settings_fn: Callable | None = None  # Dynamic model settings function
+    capabilities: list[Capability] = field(default_factory=list)  # Pluggable agent behaviors
 
     model: str = "gpt-4o-mini"
     requires_schema_injection: bool = False  # If True, inject {schema} dynamically
     knowledge_text: str = ""  # Domain knowledge from catalog (injected via domain_knowledge())
-    as_tool_parameters: Optional[Any] = None  # Dataclass/Pydantic model for structured agent-as-tool input
-    as_tool_max_turns: Optional[int] = None  # Max turns when running as sub-agent via as_tool()
-    as_tool_turn_budget: Optional[Any] = None  # TurnBudget instance for sub-agent budget management
+    as_tool_parameters: Any | None = (
+        None  # Dataclass/Pydantic model for structured agent-as-tool input
+    )
+    as_tool_max_turns: int | None = None  # Max turns when running as sub-agent via as_tool()
+    as_tool_turn_budget: Any | None = None  # TurnBudget instance for sub-agent budget management
 
     def __post_init__(self):
         """Ensure instructions is provided."""
@@ -44,11 +50,11 @@ class AgentRegistry:
         """Register an agent."""
         self._agents[agent_def.name] = agent_def
 
-    def get(self, name: str) -> Optional[AgentDefinition]:
+    def get(self, name: str) -> AgentDefinition | None:
         """Get agent definition by name."""
         return self._agents.get(name)
 
-    def list_all(self) -> List[str]:
+    def list_all(self) -> list[str]:
         """List all registered agent names."""
         return list(self._agents.keys())
 

--- a/sinan_agentic_core/registry/capability_registry.py
+++ b/sinan_agentic_core/registry/capability_registry.py
@@ -55,9 +55,7 @@ class CapabilityRegistry:
             )
         return self._factories[name]
 
-    def build(
-        self, name: str, config: dict[str, Any] | None = None
-    ) -> Capability:
+    def build(self, name: str, config: dict[str, Any] | None = None) -> Capability:
         """Resolve *name* through the registry and invoke its factory."""
         factory = self.get(name)
         return factory(dict(config) if config else {})

--- a/sinan_agentic_core/registry/guardrail_registry.py
+++ b/sinan_agentic_core/registry/guardrail_registry.py
@@ -1,12 +1,13 @@
 """Guardrail Registry - Centralized definition of all available guardrails."""
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List
 
 
 @dataclass
 class GuardrailDefinition:
     """Schema for a single guardrail."""
+
     name: str
     description: str
     function: Callable
@@ -16,33 +17,31 @@ class GuardrailDefinition:
 @dataclass
 class GuardrailRegistry:
     """Central registry of all guardrails available to agents.
-    
+
     Dataclass-driven design makes it easy to add new guardrails.
     """
-    
-    _guardrails: Dict[str, GuardrailDefinition] = field(default_factory=dict)
-    
+
+    _guardrails: dict[str, GuardrailDefinition] = field(default_factory=dict)
+
     def register(self, guardrail_def: GuardrailDefinition):
         """Register a new guardrail."""
         self._guardrails[guardrail_def.name] = guardrail_def
-    
+
     def get_guardrail(self, name: str) -> GuardrailDefinition:
         """Get a specific guardrail by name."""
         return self._guardrails.get(name)
-    
-    def get_guardrails_by_category(self, category: str) -> List[GuardrailDefinition]:
+
+    def get_guardrails_by_category(self, category: str) -> list[GuardrailDefinition]:
         """Get all guardrails in a category."""
         return [g for g in self._guardrails.values() if g.category == category]
-    
-    def get_guardrail_functions(self, guardrail_names: List[str]) -> List[Callable]:
+
+    def get_guardrail_functions(self, guardrail_names: list[str]) -> list[Callable]:
         """Get actual function objects for given guardrail names."""
         return [
-            self._guardrails[name].function 
-            for name in guardrail_names 
-            if name in self._guardrails
+            self._guardrails[name].function for name in guardrail_names if name in self._guardrails
         ]
-    
-    def get_all_functions(self) -> Dict[str, Callable]:
+
+    def get_all_functions(self) -> dict[str, Callable]:
         """Get all registered guardrail functions as a mapping."""
         return {name: gdef.function for name, gdef in self._guardrails.items()}
 
@@ -62,7 +61,7 @@ def register_guardrail(
     category: str,
 ):
     """Decorator to register a guardrail.
-    
+
     Usage:
         @register_guardrail(
             name="validate_cypher_syntax",
@@ -73,6 +72,7 @@ def register_guardrail(
         async def validate_cypher_syntax(ctx, value):
             ...
     """
+
     def decorator(func):
         guardrail_def = GuardrailDefinition(
             name=name,
@@ -82,4 +82,5 @@ def register_guardrail(
         )
         _global_registry.register(guardrail_def)
         return func
+
     return decorator

--- a/sinan_agentic_core/registry/guardrail_registry.py
+++ b/sinan_agentic_core/registry/guardrail_registry.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -10,7 +11,7 @@ class GuardrailDefinition:
 
     name: str
     description: str
-    function: Callable
+    function: Callable[..., Any]
     category: str  # "input", "output"
 
 
@@ -23,11 +24,11 @@ class GuardrailRegistry:
 
     _guardrails: dict[str, GuardrailDefinition] = field(default_factory=dict)
 
-    def register(self, guardrail_def: GuardrailDefinition):
+    def register(self, guardrail_def: GuardrailDefinition) -> None:
         """Register a new guardrail."""
         self._guardrails[guardrail_def.name] = guardrail_def
 
-    def get_guardrail(self, name: str) -> GuardrailDefinition:
+    def get_guardrail(self, name: str) -> GuardrailDefinition | None:
         """Get a specific guardrail by name."""
         return self._guardrails.get(name)
 
@@ -35,13 +36,13 @@ class GuardrailRegistry:
         """Get all guardrails in a category."""
         return [g for g in self._guardrails.values() if g.category == category]
 
-    def get_guardrail_functions(self, guardrail_names: list[str]) -> list[Callable]:
+    def get_guardrail_functions(self, guardrail_names: list[str]) -> list[Callable[..., Any]]:
         """Get actual function objects for given guardrail names."""
         return [
             self._guardrails[name].function for name in guardrail_names if name in self._guardrails
         ]
 
-    def get_all_functions(self) -> dict[str, Callable]:
+    def get_all_functions(self) -> dict[str, Callable[..., Any]]:
         """Get all registered guardrail functions as a mapping."""
         return {name: gdef.function for name, gdef in self._guardrails.items()}
 
@@ -59,7 +60,7 @@ def register_guardrail(
     name: str,
     description: str,
     category: str,
-):
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator to register a guardrail.
 
     Usage:
@@ -73,7 +74,7 @@ def register_guardrail(
             ...
     """
 
-    def decorator(func):
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         guardrail_def = GuardrailDefinition(
             name=name,
             description=description,

--- a/sinan_agentic_core/registry/tool_catalog.py
+++ b/sinan_agentic_core/registry/tool_catalog.py
@@ -84,10 +84,7 @@ class ToolCatalog:
         """
         if name not in self._raw_tools:
             available = ", ".join(sorted(self._raw_tools.keys()))
-            raise KeyError(
-                f"Tool '{name}' not found in tools.yaml. "
-                f"Available: {available}"
-            )
+            raise KeyError(f"Tool '{name}' not found in tools.yaml. " f"Available: {available}")
         raw = self._raw_tools[name]
         return ToolYamlEntry(**raw)
 
@@ -159,8 +156,7 @@ def load_tool_catalog(path: str | Path) -> ToolCatalog:
         import yaml
     except ImportError:
         raise ImportError(
-            "PyYAML is required for tool catalog loading. "
-            "Install it with: pip install pyyaml"
+            "PyYAML is required for tool catalog loading. " "Install it with: pip install pyyaml"
         )
 
     path = Path(path)

--- a/sinan_agentic_core/registry/tool_registry.py
+++ b/sinan_agentic_core/registry/tool_registry.py
@@ -8,8 +8,8 @@ Tools are registered via the @register_tool decorator. Metadata can come from:
    # Metadata loaded from tools.yaml via ToolCatalog.enrich_registry()
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Any, List
 
 
 @dataclass
@@ -20,6 +20,7 @@ class ToolDefinition:
     just a name + function. Metadata is filled in later by ToolCatalog.enrich_registry()
     or by passing values directly in the decorator.
     """
+
     name: str
     function: Callable
     description: str = ""
@@ -37,7 +38,7 @@ class ToolRegistry:
     """
 
     # Store tools by category
-    _tools: Dict[str, ToolDefinition] = field(default_factory=dict)
+    _tools: dict[str, ToolDefinition] = field(default_factory=dict)
 
     def register(self, tool_def: ToolDefinition):
         """Register a new tool."""
@@ -47,15 +48,15 @@ class ToolRegistry:
         """Get a specific tool by name."""
         return self._tools.get(name)
 
-    def get_tools_by_category(self, category: str) -> List[ToolDefinition]:
+    def get_tools_by_category(self, category: str) -> list[ToolDefinition]:
         """Get all tools in a category."""
         return [t for t in self._tools.values() if t.category == category]
 
-    def get_tool_functions(self, tool_names: List[str]) -> List[Callable]:
+    def get_tool_functions(self, tool_names: list[str]) -> list[Callable]:
         """Get actual function objects for given tool names."""
         return [self._tools[name].function for name in tool_names if name in self._tools]
 
-    def to_instruction_text(self, tool_names: List[str] = None) -> str:
+    def to_instruction_text(self, tool_names: list[str] = None) -> str:
         """Convert tools to instruction text for agent prompts.
 
         Args:
@@ -69,7 +70,7 @@ class ToolRegistry:
         text = "## Available Tools\n\n"
 
         # Group by category
-        by_category: Dict[str, List[ToolDefinition]] = {}
+        by_category: dict[str, list[ToolDefinition]] = {}
         for tool in tools:
             if tool.category not in by_category:
                 by_category[tool.category] = []
@@ -125,6 +126,7 @@ def register_tool(
         @function_tool
         async def search(ctx, query: str) -> str: ...
     """
+
     def decorator(func):
         tool_def = ToolDefinition(
             name=name,
@@ -137,4 +139,5 @@ def register_tool(
         )
         _global_registry.register(tool_def)
         return func
+
     return decorator

--- a/sinan_agentic_core/registry/tool_registry.py
+++ b/sinan_agentic_core/registry/tool_registry.py
@@ -8,8 +8,9 @@ Tools are registered via the @register_tool decorator. Metadata can come from:
    # Metadata loaded from tools.yaml via ToolCatalog.enrich_registry()
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -22,7 +23,7 @@ class ToolDefinition:
     """
 
     name: str
-    function: Callable
+    function: Callable[..., Any]
     description: str = ""
     category: str = ""
     parameters_description: str = ""
@@ -40,11 +41,11 @@ class ToolRegistry:
     # Store tools by category
     _tools: dict[str, ToolDefinition] = field(default_factory=dict)
 
-    def register(self, tool_def: ToolDefinition):
+    def register(self, tool_def: ToolDefinition) -> None:
         """Register a new tool."""
         self._tools[tool_def.name] = tool_def
 
-    def get_tool(self, name: str) -> ToolDefinition:
+    def get_tool(self, name: str) -> ToolDefinition | None:
         """Get a specific tool by name."""
         return self._tools.get(name)
 
@@ -52,16 +53,17 @@ class ToolRegistry:
         """Get all tools in a category."""
         return [t for t in self._tools.values() if t.category == category]
 
-    def get_tool_functions(self, tool_names: list[str]) -> list[Callable]:
+    def get_tool_functions(self, tool_names: list[str]) -> list[Callable[..., Any]]:
         """Get actual function objects for given tool names."""
         return [self._tools[name].function for name in tool_names if name in self._tools]
 
-    def to_instruction_text(self, tool_names: list[str] = None) -> str:
+    def to_instruction_text(self, tool_names: list[str] | None = None) -> str:
         """Convert tools to instruction text for agent prompts.
 
         Args:
             tool_names: Specific tools to include, or None for all
         """
+        tools: Iterable[ToolDefinition]
         if tool_names is None:
             tools = self._tools.values()
         else:
@@ -104,7 +106,7 @@ def register_tool(
     parameters_description: str = "",
     returns_description: str = "",
     recovery_hint: str = "",
-):
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator to register a tool function.
 
     Can be used with full metadata (backward compatible)::
@@ -127,7 +129,7 @@ def register_tool(
         async def search(ctx, query: str) -> str: ...
     """
 
-    def decorator(func):
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         tool_def = ToolDefinition(
             name=name,
             function=func,

--- a/sinan_agentic_core/services/__init__.py
+++ b/sinan_agentic_core/services/__init__.py
@@ -12,19 +12,19 @@ Public API::
     from sinan_agentic_core.services import StreamingHelper, AgentStartEvent, ...
 """
 
+from .chat import chat, chat_streamed, chat_with_hooks
 from .events import (
-    StreamingHelper,
-    BaseEvent,
-    AgentStartEvent,
     AgentCompleteEvent,
+    AgentStartEvent,
+    AnswerEvent,
+    BaseEvent,
+    ErrorEvent,
+    StreamingHelper,
+    StreamingTextEvent,
     ThinkingEvent,
     ToolCallEvent,
-    StreamingTextEvent,
-    AnswerEvent,
-    ErrorEvent,
 )
 from .hooks import StreamingRunHooks
-from .chat import chat, chat_with_hooks, chat_streamed
 
 __all__ = [
     # Chat

--- a/sinan_agentic_core/services/chat.py
+++ b/sinan_agentic_core/services/chat.py
@@ -98,7 +98,7 @@ def _usage_to_dict(result: Any) -> dict[str, Any]:
 async def chat(
     message: str,
     agent_name: str | None = None,
-    session: AgentSession = None,
+    session: AgentSession | None = None,
     context: Any = None,
     model_override: str | None = None,
     agent: Agent | None = None,
@@ -119,6 +119,8 @@ async def chat(
         ``{"success": True, "response": str, "session_id": str, "tools_called": list, "usage": dict}``
         or ``{"success": False, "error": str, "session_id": str}`` on failure.
     """
+    if session is None:
+        raise ValueError("'session' is required")
     try:
         resolved = _resolve_agent(agent, agent_name, model_override)
 
@@ -149,7 +151,7 @@ async def chat(
 async def chat_with_hooks(
     message: str,
     agent_name: str | None = None,
-    session: AgentSession = None,
+    session: AgentSession | None = None,
     context: Any = None,
     tool_friendly_names: dict[str, str] | None = None,
     model_override: str | None = None,
@@ -180,7 +182,9 @@ async def chat_with_hooks(
             {"event": "answer",     "data": {"response": "...", "tools_called": [...]}}
             {"event": "error",      "data": {"error": "..."}}
     """
-    queue: asyncio.Queue = asyncio.Queue()
+    if session is None:
+        raise ValueError("'session' is required")
+    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     hooks = StreamingRunHooks(queue, tool_friendly_names)
 
     try:
@@ -191,7 +195,7 @@ async def chat_with_hooks(
         history = await session.get_items()
 
         # Run agent with hooks in the background
-        async def _run():
+        async def _run() -> Any:
             run_kwargs: dict[str, Any] = {
                 "starting_agent": resolved,
                 "input": history,
@@ -237,7 +241,7 @@ async def chat_with_hooks(
 async def chat_streamed(
     message: str,
     agent_name: str | None = None,
-    session: AgentSession = None,
+    session: AgentSession | None = None,
     context: Any = None,
     model_override: str | None = None,
     agent: Agent | None = None,
@@ -268,6 +272,8 @@ async def chat_streamed(
             {"event": "answer",          "data": {"response": "...", "tools_called": [...]}}
             {"event": "error",           "data": {"error": "..."}}
     """
+    if session is None:
+        raise ValueError("'session' is required")
     try:
         resolved = _resolve_agent(agent, agent_name, model_override)
         await session.add_items([{"role": "user", "content": message}])

--- a/sinan_agentic_core/services/chat.py
+++ b/sinan_agentic_core/services/chat.py
@@ -30,9 +30,10 @@ Usage:
 
 import asyncio
 import logging
-from typing import Any, AsyncGenerator, Dict, List, Optional
+from collections.abc import AsyncGenerator
+from typing import Any
 
-from agents import Agent, Runner, ItemHelpers, Usage
+from agents import Agent, ItemHelpers, Runner, Usage
 from openai.types.responses import ResponseTextDeltaEvent
 
 from ..registry.agent_factory import create_agent_from_registry
@@ -43,9 +44,9 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_agent(
-    agent: Optional[Agent],
-    agent_name: Optional[str],
-    model_override: Optional[str] = None,
+    agent: Agent | None,
+    agent_name: str | None,
+    model_override: str | None = None,
 ) -> Agent:
     """Return a ready-to-run Agent, either pre-built or from the registry.
 
@@ -67,7 +68,7 @@ def _resolve_agent(
     raise ValueError("Provide either 'agent' (pre-built) or 'agent_name' (registry lookup)")
 
 
-def _usage_to_dict(result: Any) -> Dict[str, Any]:
+def _usage_to_dict(result: Any) -> dict[str, Any]:
     """Aggregate token usage from all LLM responses in a run result.
 
     Args:
@@ -96,12 +97,12 @@ def _usage_to_dict(result: Any) -> Dict[str, Any]:
 
 async def chat(
     message: str,
-    agent_name: Optional[str] = None,
+    agent_name: str | None = None,
     session: AgentSession = None,
     context: Any = None,
-    model_override: Optional[str] = None,
-    agent: Optional[Agent] = None,
-) -> Dict[str, Any]:
+    model_override: str | None = None,
+    agent: Agent | None = None,
+) -> dict[str, Any]:
     """Run a single chat turn (non-streaming).
 
     Args:
@@ -124,7 +125,7 @@ async def chat(
         await session.add_items([{"role": "user", "content": message}])
         history = await session.get_items()
 
-        run_kwargs: Dict[str, Any] = {"starting_agent": resolved, "input": history}
+        run_kwargs: dict[str, Any] = {"starting_agent": resolved, "input": history}
         if context is not None:
             run_kwargs["context"] = context
 
@@ -147,13 +148,13 @@ async def chat(
 
 async def chat_with_hooks(
     message: str,
-    agent_name: Optional[str] = None,
+    agent_name: str | None = None,
     session: AgentSession = None,
     context: Any = None,
-    tool_friendly_names: Optional[Dict[str, str]] = None,
-    model_override: Optional[str] = None,
-    agent: Optional[Agent] = None,
-) -> AsyncGenerator[Dict[str, Any], None]:
+    tool_friendly_names: dict[str, str] | None = None,
+    model_override: str | None = None,
+    agent: Agent | None = None,
+) -> AsyncGenerator[dict[str, Any], None]:
     """Chat with real-time tool-call notifications via ``RunHooks``.
 
     Uses ``Runner.run()`` internally — the agent runs to completion, but
@@ -191,8 +192,10 @@ async def chat_with_hooks(
 
         # Run agent with hooks in the background
         async def _run():
-            run_kwargs: Dict[str, Any] = {
-                "starting_agent": resolved, "input": history, "hooks": hooks,
+            run_kwargs: dict[str, Any] = {
+                "starting_agent": resolved,
+                "input": history,
+                "hooks": hooks,
             }
             if context is not None:
                 run_kwargs["context"] = context
@@ -233,12 +236,12 @@ async def chat_with_hooks(
 
 async def chat_streamed(
     message: str,
-    agent_name: Optional[str] = None,
+    agent_name: str | None = None,
     session: AgentSession = None,
     context: Any = None,
-    model_override: Optional[str] = None,
-    agent: Optional[Agent] = None,
-) -> AsyncGenerator[Dict[str, Any], None]:
+    model_override: str | None = None,
+    agent: Agent | None = None,
+) -> AsyncGenerator[dict[str, Any], None]:
     """Chat with token-level streaming via ``Runner.run_streamed()``.
 
     Yields events for every text delta, tool invocation, tool output,
@@ -270,13 +273,13 @@ async def chat_streamed(
         await session.add_items([{"role": "user", "content": message}])
         history = await session.get_items()
 
-        run_kwargs: Dict[str, Any] = {"starting_agent": resolved, "input": history}
+        run_kwargs: dict[str, Any] = {"starting_agent": resolved, "input": history}
         if context is not None:
             run_kwargs["context"] = context
 
         result = Runner.run_streamed(**run_kwargs)
 
-        tools_called: List[str] = []
+        tools_called: list[str] = []
 
         async for event in result.stream_events():
             # Token-level text deltas
@@ -291,11 +294,7 @@ async def chat_streamed(
 
                 if item.type == "tool_call_item":
                     raw = getattr(item, "raw_item", None)
-                    name = (
-                        getattr(item, "name", None)
-                        or getattr(raw, "name", None)
-                        or "unknown"
-                    )
+                    name = getattr(item, "name", None) or getattr(raw, "name", None) or "unknown"
                     tools_called.append(name)
                     yield {
                         "event": "tool_call",

--- a/sinan_agentic_core/services/events.py
+++ b/sinan_agentic_core/services/events.py
@@ -11,9 +11,9 @@ Usage:
     helper.emit_agent_start("analyzer", iteration=1)
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
-
+from typing import Any
 
 # -- Event dataclasses -------------------------------------------------------
 
@@ -24,7 +24,7 @@ class BaseEvent:
 
     event_type: str
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {"event_type": self.event_type}
 
 
@@ -36,7 +36,7 @@ class AgentStartEvent(BaseEvent):
     agent_name: str = ""
     iteration: int = 1
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "event_type": self.event_type,
             "agent_name": self.agent_name,
@@ -52,7 +52,7 @@ class AgentCompleteEvent(BaseEvent):
     agent_name: str = ""
     iteration: int = 1
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "event_type": self.event_type,
             "agent_name": self.agent_name,
@@ -66,9 +66,9 @@ class ThinkingEvent(BaseEvent):
 
     event_type: str = field(default="thinking", init=False)
     message: str = ""
-    agent_name: Optional[str] = None
+    agent_name: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "event_type": self.event_type,
             "message": self.message,
@@ -82,10 +82,10 @@ class ToolCallEvent(BaseEvent):
 
     event_type: str = field(default="tool_call", init=False)
     tool_name: str = ""
-    arguments: Dict[str, Any] = field(default_factory=dict)
-    agent_name: Optional[str] = None
+    arguments: dict[str, Any] = field(default_factory=dict)
+    agent_name: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "event_type": self.event_type,
             "tool_name": self.tool_name,
@@ -100,9 +100,9 @@ class StreamingTextEvent(BaseEvent):
 
     event_type: str = field(default="text_delta", init=False)
     text: str = ""
-    agent_name: Optional[str] = None
+    agent_name: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "event_type": self.event_type,
             "text": self.text,
@@ -116,11 +116,11 @@ class AnswerEvent(BaseEvent):
 
     event_type: str = field(default="answer", init=False)
     answer: str = ""
-    sources: List[Any] = field(default_factory=list)
-    followup_question: Optional[str] = None
-    confidence: Optional[float] = None
+    sources: list[Any] = field(default_factory=list)
+    followup_question: str | None = None
+    confidence: float | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "event_type": self.event_type,
             "answer": self.answer,
@@ -136,9 +136,9 @@ class ErrorEvent(BaseEvent):
 
     event_type: str = field(default="error", init=False)
     error: str = ""
-    agent_name: Optional[str] = None
+    agent_name: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "event_type": self.event_type,
             "error": self.error,
@@ -165,7 +165,7 @@ class StreamingHelper:
         helper.emit_answer("42", sources=["data.csv"])
     """
 
-    def __init__(self, event_callback: Optional[Callable] = None):
+    def __init__(self, event_callback: Callable | None = None):
         self.event_callback = event_callback
 
     def emit_agent_start(self, agent_name: str, iteration: int = 1) -> None:
@@ -179,9 +179,9 @@ class StreamingHelper:
     def emit_answer(
         self,
         answer: str,
-        sources: Optional[List[Any]] = None,
-        followup_question: Optional[str] = None,
-        confidence: Optional[float] = None,
+        sources: list[Any] | None = None,
+        followup_question: str | None = None,
+        confidence: float | None = None,
     ) -> None:
         if self.event_callback:
             self.event_callback(

--- a/sinan_agentic_core/services/events.py
+++ b/sinan_agentic_core/services/events.py
@@ -165,7 +165,7 @@ class StreamingHelper:
         helper.emit_answer("42", sources=["data.csv"])
     """
 
-    def __init__(self, event_callback: Callable | None = None):
+    def __init__(self, event_callback: Callable[[BaseEvent], None] | None = None):
         self.event_callback = event_callback
 
     def emit_agent_start(self, agent_name: str, iteration: int = 1) -> None:

--- a/sinan_agentic_core/services/hooks.py
+++ b/sinan_agentic_core/services/hooks.py
@@ -19,7 +19,7 @@ Usage:
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from agents import RunHooks
 
@@ -42,7 +42,7 @@ class StreamingRunHooks(RunHooks):
     def __init__(
         self,
         event_queue: asyncio.Queue,
-        tool_friendly_names: Optional[Dict[str, str]] = None,
+        tool_friendly_names: dict[str, str] | None = None,
     ):
         """
         Args:
@@ -52,7 +52,7 @@ class StreamingRunHooks(RunHooks):
         """
         self.event_queue = event_queue
         self.tool_friendly_names = tool_friendly_names or {}
-        self.tools_called: List[str] = []
+        self.tools_called: list[str] = []
 
     def _friendly_name(self, tool_name: str) -> str:
         return self.tool_friendly_names.get(tool_name, tool_name.replace("_", " "))
@@ -62,33 +62,39 @@ class StreamingRunHooks(RunHooks):
         friendly = self._friendly_name(tool_name)
         self.tools_called.append(tool_name)
 
-        await self.event_queue.put({
-            "event": "tool_start",
-            "data": {
-                "tool": tool_name,
-                "friendly_name": friendly,
-                "message": f"Fetching {friendly}...",
-            },
-        })
+        await self.event_queue.put(
+            {
+                "event": "tool_start",
+                "data": {
+                    "tool": tool_name,
+                    "friendly_name": friendly,
+                    "message": f"Fetching {friendly}...",
+                },
+            }
+        )
         logger.debug("Tool started: %s", tool_name)
 
     async def on_tool_end(self, context: Any, agent: Any, tool: Any, result: Any) -> None:
         tool_name = getattr(tool, "name", str(tool))
         friendly = self._friendly_name(tool_name)
 
-        await self.event_queue.put({
-            "event": "tool_end",
-            "data": {
-                "tool": tool_name,
-                "friendly_name": friendly,
-                "message": f"Completed {friendly}",
-            },
-        })
+        await self.event_queue.put(
+            {
+                "event": "tool_end",
+                "data": {
+                    "tool": tool_name,
+                    "friendly_name": friendly,
+                    "message": f"Completed {friendly}",
+                },
+            }
+        )
         logger.debug("Tool ended: %s", tool_name)
 
     async def on_agent_start(self, context: Any, agent: Any) -> None:
-        await self.event_queue.put({
-            "event": "thinking",
-            "data": {"message": "Analyzing your question..."},
-        })
+        await self.event_queue.put(
+            {
+                "event": "thinking",
+                "data": {"message": "Analyzing your question..."},
+            }
+        )
         logger.debug("Agent started: %s", getattr(agent, "name", agent))

--- a/sinan_agentic_core/services/hooks.py
+++ b/sinan_agentic_core/services/hooks.py
@@ -41,9 +41,9 @@ class StreamingRunHooks(RunHooks):
 
     def __init__(
         self,
-        event_queue: asyncio.Queue,
+        event_queue: asyncio.Queue[Any],
         tool_friendly_names: dict[str, str] | None = None,
-    ):
+    ) -> None:
         """
         Args:
             event_queue: Queue that receives event dicts.

--- a/sinan_agentic_core/session/agent_session.py
+++ b/sinan_agentic_core/session/agent_session.py
@@ -3,10 +3,12 @@
 This is a generic conversation history manager that works with the OpenAI Agents SDK.
 """
 
-from typing import TYPE_CHECKING, Iterable, List, Optional, Dict, Any
-from agents.memory.session import SessionABC
-from agents.items import TResponseInputItem
 import json
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+from agents.items import TResponseInputItem
+from agents.memory.session import SessionABC
 
 if TYPE_CHECKING:
     from ..core.capabilities import Capability
@@ -15,21 +17,21 @@ if TYPE_CHECKING:
 
 class ConversationHistory:
     """Generic conversation history container.
-    
+
     Stores messages in a simple list format compatible with OpenAI SDK.
     Extend this for your specific storage needs (database persistence, etc.).
     """
-    
+
     def __init__(self):
-        self.messages: List[Dict[str, Any]] = []
-    
-    def to_list_dict(self) -> List[Dict[str, Any]]:
+        self.messages: list[dict[str, Any]] = []
+
+    def to_list_dict(self) -> list[dict[str, Any]]:
         """Convert to list of message dictionaries."""
         return self.messages.copy()
-    
+
     def add_message(self, role: str, content: str, **kwargs) -> None:
         """Add a message to history.
-        
+
         Args:
             role: Message role ('user', 'assistant', 'system')
             content: Message content
@@ -38,7 +40,7 @@ class ConversationHistory:
         msg = {"role": role, "content": content}
         msg.update(kwargs)
         self.messages.append(msg)
-    
+
     def clear(self) -> None:
         """Clear all messages."""
         self.messages.clear()
@@ -46,31 +48,31 @@ class ConversationHistory:
 
 class AgentSession(SessionABC):
     """Generic session implementation for OpenAI Agents SDK.
-    
+
     Manages conversation history for multi-agent workflows with automatic
     summarization when history becomes too long.
-    
+
     Usage:
         session = AgentSession(session_id="unique-id")
-        
+
         # Add messages manually
         await session.add_items([
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there!"}
         ])
-        
+
         # Get history
         history = await session.get_items()
     """
-    
+
     def __init__(
-        self, 
-        session_id: str, 
-        initial_history: Optional[ConversationHistory] = None,
-        max_items: int = 50
+        self,
+        session_id: str,
+        initial_history: ConversationHistory | None = None,
+        max_items: int = 50,
     ):
         """Initialize session.
-        
+
         Args:
             session_id: Unique identifier for this session
             initial_history: Optional existing conversation history
@@ -79,14 +81,14 @@ class AgentSession(SessionABC):
         self.session_id = session_id
         self.history = initial_history or ConversationHistory()
         self.max_items = max_items
-        self.metadata: Dict[str, Any] = {}  # Store arbitrary session metadata
-    
-    async def get_items(self, limit: int | None = None) -> List[TResponseInputItem]:
+        self.metadata: dict[str, Any] = {}  # Store arbitrary session metadata
+
+    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
         """Retrieve conversation history as list of dicts.
-        
+
         Args:
             limit: Optional limit on number of items to return (from end)
-            
+
         Returns:
             List of message dicts compatible with Agent SDK
         """
@@ -94,10 +96,10 @@ class AgentSession(SessionABC):
         if limit:
             return items[-limit:]
         return items
-    
-    async def add_items(self, items: List[TResponseInputItem]) -> None:
+
+    async def add_items(self, items: list[TResponseInputItem]) -> None:
         """Add new messages to conversation history.
-        
+
         Args:
             items: List of message dicts to add
         """
@@ -106,14 +108,14 @@ class AgentSession(SessionABC):
             content = item.get("content", "")
             if not content or (isinstance(content, str) and not content.strip()):
                 continue
-            
+
             # Clean up SDK's structured output format
             # SDK returns: [{'text': '{"response":...}', 'type': 'output_text', ...}]
             # We want: just the JSON string
             if isinstance(content, list) and len(content) > 0:
-                if isinstance(content[0], dict) and 'text' in content[0]:
-                    content = content[0]['text']
-            
+                if isinstance(content[0], dict) and "text" in content[0]:
+                    content = content[0]["text"]
+
             # For assistant messages with structured output, extract response
             if item.get("role") == "assistant" and isinstance(content, str):
                 try:
@@ -122,68 +124,65 @@ class AgentSession(SessionABC):
                         content = json.dumps(parsed["response"])
                 except (json.JSONDecodeError, ValueError):
                     pass
-            
+
             # Create message dict
-            msg = {
-                "role": item.get("role"),
-                "content": str(content)
-            }
-            
+            msg = {"role": item.get("role"), "content": str(content)}
+
             # Add optional fields
             if "name" in item:
                 msg["name"] = item["name"]
             if "tool_call_id" in item:
                 msg["tool_call_id"] = item["tool_call_id"]
-            
+
             self.history.messages.append(msg)
-    
+
     async def pop_item(self) -> TResponseInputItem | None:
         """Remove and return the most recent message.
-        
+
         Returns:
             Last message as dict, or None if empty
         """
         if self.history.messages:
             return self.history.messages.pop()
         return None
-    
+
     async def clear_session(self) -> None:
         """Clear all messages from history."""
         self.history.messages.clear()
-    
+
     def get_history(self) -> ConversationHistory:
         """Get full ConversationHistory object.
-        
+
         Returns:
             ConversationHistory for debugging/persistence
         """
         return self.history
-    
+
     def needs_summarization(self) -> bool:
         """Check if session has exceeded max items threshold.
-        
+
         Returns:
             True if session should be summarized
         """
         return len(self.history.messages) > self.max_items
-    
+
     def get_message_count(self) -> int:
         """Get current number of messages in session.
-        
+
         Returns:
             Number of messages
         """
         return len(self.history.messages)
-    
+
     def set_metadata(self, key: str, value: Any) -> None:
         """Store metadata in session.
-        
+
         Args:
             key: Metadata key
             value: Metadata value
         """
         self.metadata[key] = value
-    
+
     def get_metadata(self, key: str, default: Any = None) -> Any:
         """Retrieve session metadata.
 

--- a/sinan_agentic_core/session/agent_session.py
+++ b/sinan_agentic_core/session/agent_session.py
@@ -5,7 +5,7 @@ This is a generic conversation history manager that works with the OpenAI Agents
 
 import json
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from agents.items import TResponseInputItem
 from agents.memory.session import SessionABC
@@ -22,14 +22,14 @@ class ConversationHistory:
     Extend this for your specific storage needs (database persistence, etc.).
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.messages: list[dict[str, Any]] = []
 
     def to_list_dict(self) -> list[dict[str, Any]]:
         """Convert to list of message dictionaries."""
         return self.messages.copy()
 
-    def add_message(self, role: str, content: str, **kwargs) -> None:
+    def add_message(self, role: str, content: str, **kwargs: Any) -> None:
         """Add a message to history.
 
         Args:
@@ -70,7 +70,7 @@ class AgentSession(SessionABC):
         session_id: str,
         initial_history: ConversationHistory | None = None,
         max_items: int = 50,
-    ):
+    ) -> None:
         """Initialize session.
 
         Args:
@@ -94,8 +94,8 @@ class AgentSession(SessionABC):
         """
         items = self.history.to_list_dict()
         if limit:
-            return items[-limit:]
-        return items
+            return cast(list[TResponseInputItem], items[-limit:])
+        return cast(list[TResponseInputItem], items)
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
         """Add new messages to conversation history.
@@ -103,7 +103,11 @@ class AgentSession(SessionABC):
         Args:
             items: List of message dicts to add
         """
-        for item in items:
+        for raw_item in items:
+            # Items arrive as the SDK's TResponseInputItem union of TypedDicts;
+            # we treat them as plain dicts internally for storage.
+            item = cast(dict[str, Any], raw_item)
+
             # Skip empty messages
             content = item.get("content", "")
             if not content or (isinstance(content, str) and not content.strip()):
@@ -126,7 +130,7 @@ class AgentSession(SessionABC):
                     pass
 
             # Create message dict
-            msg = {"role": item.get("role"), "content": str(content)}
+            msg: dict[str, Any] = {"role": item.get("role"), "content": str(content)}
 
             # Add optional fields
             if "name" in item:
@@ -143,7 +147,7 @@ class AgentSession(SessionABC):
             Last message as dict, or None if empty
         """
         if self.history.messages:
-            return self.history.messages.pop()
+            return cast(TResponseInputItem, self.history.messages.pop())
         return None
 
     async def clear_session(self) -> None:

--- a/sinan_agentic_core/session/sqlite_store.py
+++ b/sinan_agentic_core/session/sqlite_store.py
@@ -26,7 +26,7 @@ import logging
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +118,7 @@ class SQLiteSessionStore:
     # Session management
     # -----------------------------------------------------------------
 
-    def get_or_create_session(self, session_id: str) -> Dict[str, Any]:
+    def get_or_create_session(self, session_id: str) -> dict[str, Any]:
         """Get existing session or create a new one.
 
         Returns:
@@ -176,7 +176,7 @@ class SQLiteSessionStore:
             conn.commit()
             return cursor.rowcount > 0
 
-    def get_active_sessions(self) -> List[Dict[str, Any]]:
+    def get_active_sessions(self) -> list[dict[str, Any]]:
         """Get all active (non-archived) sessions with message counts."""
         with self._connect() as conn:
             cursor = conn.cursor()
@@ -190,7 +190,7 @@ class SQLiteSessionStore:
             """)
             return [dict(row) for row in cursor.fetchall()]
 
-    def get_archived_sessions(self) -> List[Dict[str, Any]]:
+    def get_archived_sessions(self) -> list[dict[str, Any]]:
         """Get all archived sessions with message counts."""
         with self._connect() as conn:
             cursor = conn.cursor()
@@ -223,7 +223,7 @@ class SQLiteSessionStore:
         session_id: str,
         role: str,
         content: str,
-        metadata: Optional[Dict] = None,
+        metadata: dict | None = None,
     ) -> int:
         """Add a message to a session.
 
@@ -267,7 +267,7 @@ class SQLiteSessionStore:
             conn.commit()
             return message_id
 
-    def get_messages(self, session_id: str, limit: int = 100) -> List[Dict[str, Any]]:
+    def get_messages(self, session_id: str, limit: int = 100) -> list[dict[str, Any]]:
         """Get messages for a session with full metadata.
 
         Returns:
@@ -288,15 +288,17 @@ class SQLiteSessionStore:
 
             messages = []
             for row in cursor.fetchall():
-                messages.append({
-                    "role": row["role"],
-                    "content": row["content"],
-                    "created_at": row["created_at"],
-                    "metadata": json.loads(row["metadata"]) if row["metadata"] else {},
-                })
+                messages.append(
+                    {
+                        "role": row["role"],
+                        "content": row["content"],
+                        "created_at": row["created_at"],
+                        "metadata": json.loads(row["metadata"]) if row["metadata"] else {},
+                    }
+                )
             return messages
 
-    def get_conversation_history(self, session_id: str) -> List[Dict[str, str]]:
+    def get_conversation_history(self, session_id: str) -> list[dict[str, str]]:
         """Get conversation history in OpenAI-compatible format.
 
         Returns:
@@ -349,7 +351,7 @@ class SQLiteSessionStore:
         self,
         session_id: str,
         capability_key: str,
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Return the stored snapshot dict, or ``None`` when absent."""
         with self._connect() as conn:
             cursor = conn.cursor()

--- a/sinan_agentic_core/session/sqlite_store.py
+++ b/sinan_agentic_core/session/sqlite_store.py
@@ -24,6 +24,7 @@ Usage:
 import json
 import logging
 import sqlite3
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -41,7 +42,7 @@ class SQLiteSessionStore:
     - Archiving and deleting sessions
     """
 
-    def __init__(self, db_path: str = "data/conversations.db"):
+    def __init__(self, db_path: str = "data/conversations.db") -> None:
         """
         Args:
             db_path: Path to the SQLite database file.
@@ -52,7 +53,7 @@ class SQLiteSessionStore:
         self._init_schema()
 
     @contextmanager
-    def _connect(self):
+    def _connect(self) -> Iterator[sqlite3.Connection]:
         """Context manager for database connections."""
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
@@ -61,7 +62,7 @@ class SQLiteSessionStore:
         finally:
             conn.close()
 
-    def _init_schema(self):
+    def _init_schema(self) -> None:
         """Create tables if they don't exist."""
         with self._connect() as conn:
             cursor = conn.cursor()
@@ -157,7 +158,7 @@ class SQLiteSessionStore:
                 (session_id,),
             )
             conn.commit()
-            return cursor.rowcount > 0
+            return bool(cursor.rowcount > 0)
 
     def clear_session(self, session_id: str) -> bool:
         """Delete a session and all its messages permanently.
@@ -174,7 +175,7 @@ class SQLiteSessionStore:
             )
             cursor.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
             conn.commit()
-            return cursor.rowcount > 0
+            return bool(cursor.rowcount > 0)
 
     def get_active_sessions(self) -> list[dict[str, Any]]:
         """Get all active (non-archived) sessions with message counts."""
@@ -212,7 +213,8 @@ class SQLiteSessionStore:
                 "SELECT COUNT(*) as count FROM messages WHERE session_id = ?",
                 (session_id,),
             )
-            return cursor.fetchone()["count"]
+            count: int = cursor.fetchone()["count"]
+            return count
 
     # -----------------------------------------------------------------
     # Message operations
@@ -223,7 +225,7 @@ class SQLiteSessionStore:
         session_id: str,
         role: str,
         content: str,
-        metadata: dict | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> int:
         """Add a message to a session.
 
@@ -265,6 +267,7 @@ class SQLiteSessionStore:
                 )
 
             conn.commit()
+            assert message_id is not None
             return message_id
 
     def get_messages(self, session_id: str, limit: int = 100) -> list[dict[str, Any]]:

--- a/sinan_agentic_core/tools/__init__.py
+++ b/sinan_agentic_core/tools/__init__.py
@@ -5,7 +5,7 @@ Define your agent tools here. Tools are functions that agents can call.
 Example:
     from agents import function_tool
     from sinan_agentic_core.registry import register_tool
-    
+
     @register_tool(
         name="my_tool",
         description="Does something useful",

--- a/tests/test_agent_catalog.py
+++ b/tests/test_agent_catalog.py
@@ -1,7 +1,6 @@
 """Tests for AgentCatalog — tool groups, conditional tools, agent-level conditions, knowledge."""
 
 import textwrap
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -29,7 +28,6 @@ from sinan_agentic_core.registry.capability_registry import (
     get_capability_registry,
     register_capability,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -309,9 +307,7 @@ class TestAgentYamlEntry:
         assert entry.tools == ["a", "b"]
 
     def test_with_knowledge(self):
-        entry = AgentYamlEntry(
-            model="fast", description="test", knowledge_text="Domain knowledge."
-        )
+        entry = AgentYamlEntry(model="fast", description="test", knowledge_text="Domain knowledge.")
         assert entry.knowledge_text == "Domain knowledge."
 
     def test_no_turn_budget_by_default(self):
@@ -519,9 +515,7 @@ class TestLoadAgentCatalogWithKnowledge:
         kdir.mkdir()
         (kdir / "global.yaml").write_text("content: |\n  Domain info.\n")
 
-        catalog = load_agent_catalog(
-            tmp_path / "agents.yaml", knowledge_dir="knowledge"
-        )
+        catalog = load_agent_catalog(tmp_path / "agents.yaml", knowledge_dir="knowledge")
         entry = catalog.get("agent")
         assert "Domain info." in entry.knowledge_text
 
@@ -655,9 +649,7 @@ class TestParseCapabilities:
             "a",
             [{"name": "turn_budget", "config": {"default_turns": 5}}],
         )
-        assert refs == [
-            CapabilityRef(name="turn_budget", config={"default_turns": 5})
-        ]
+        assert refs == [CapabilityRef(name="turn_budget", config={"default_turns": 5})]
 
     def test_dict_form_without_config(self) -> None:
         refs = _parse_capabilities("a", [{"name": "error_recovery"}])
@@ -665,15 +657,11 @@ class TestParseCapabilities:
 
     def test_dict_form_with_null_config(self) -> None:
         # YAML may parse a missing value as None — must normalize to {}.
-        refs = _parse_capabilities(
-            "a", [{"name": "turn_budget", "config": None}]
-        )
+        refs = _parse_capabilities("a", [{"name": "turn_budget", "config": None}])
         assert refs == [CapabilityRef(name="turn_budget", config={})]
 
     def test_unknown_name_raises(self) -> None:
-        with pytest.raises(
-            CapabilityNotFoundError, match="unknown capability"
-        ):
+        with pytest.raises(CapabilityNotFoundError, match="unknown capability"):
             _parse_capabilities("a", ["does_not_exist"])
 
     def test_missing_name_key_raises(self) -> None:
@@ -703,9 +691,7 @@ class TestCatalogParsesCapabilitiesBlock:
         (tmp_path / "agents.yaml").write_text(yaml_content)
         catalog = load_agent_catalog(tmp_path / "agents.yaml")
         entry = catalog.get("chatbot")
-        assert entry.capabilities == [
-            CapabilityRef(name="turn_budget", config={})
-        ]
+        assert entry.capabilities == [CapabilityRef(name="turn_budget", config={})]
 
     def test_dict_form_in_yaml(self, tmp_path) -> None:
         yaml_content = textwrap.dedent("""\
@@ -742,9 +728,7 @@ class TestCatalogParsesCapabilitiesBlock:
         """)
         (tmp_path / "agents.yaml").write_text(yaml_content)
         catalog = load_agent_catalog(tmp_path / "agents.yaml")
-        with pytest.raises(
-            CapabilityNotFoundError, match="never_registered_capability"
-        ):
+        with pytest.raises(CapabilityNotFoundError, match="never_registered_capability"):
             catalog.get("chatbot")
 
     def test_no_capabilities_block_returns_empty(self, tmp_path) -> None:
@@ -763,9 +747,7 @@ class TestCatalogParsesCapabilitiesBlock:
 
 class TestBuildCapabilities:
     def test_no_capabilities_no_shorthand(self) -> None:
-        entry = AgentYamlEntry(
-            model="fast", description="test", error_recovery=False
-        )
+        entry = AgentYamlEntry(model="fast", description="test", error_recovery=False)
         assert entry.build_capabilities() == []
 
     def test_shorthand_only_turn_budget(self) -> None:
@@ -783,9 +765,7 @@ class TestBuildCapabilities:
         assert built[0].absolute_max == 20
 
     def test_shorthand_only_error_recovery(self) -> None:
-        entry = AgentYamlEntry(
-            model="fast", description="test", error_recovery=True
-        )
+        entry = AgentYamlEntry(model="fast", description="test", error_recovery=True)
         built = entry.build_capabilities()
         assert len(built) == 1
         assert isinstance(built[0], ToolErrorRecovery)
@@ -808,9 +788,7 @@ class TestBuildCapabilities:
         assert built[0].label == "x"
         assert built[0].level == 2
 
-    def test_mixing_shorthand_and_explicit_list(
-        self, spy_capability_registered
-    ) -> None:
+    def test_mixing_shorthand_and_explicit_list(self, spy_capability_registered) -> None:
         entry = AgentYamlEntry(
             model="fast",
             description="test",
@@ -838,11 +816,7 @@ class TestBuildCapabilities:
             model="fast",
             description="test",
             error_recovery=False,
-            capabilities=[
-                CapabilityRef(
-                    name="turn_budget", config={"default_turns": 4}
-                )
-            ],
+            capabilities=[CapabilityRef(name="turn_budget", config={"default_turns": 4})],
         )
         built = entry.build_capabilities()
         assert len(built) == 1
@@ -851,9 +825,7 @@ class TestBuildCapabilities:
 
 
 class TestCatalogIntegrationWithCapabilities:
-    def test_full_yaml_with_mixed_forms(
-        self, tmp_path, spy_capability_registered
-    ) -> None:
+    def test_full_yaml_with_mixed_forms(self, tmp_path, spy_capability_registered) -> None:
         yaml_content = textwrap.dedent(f"""\
             agents:
               chatbot:

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -17,7 +17,6 @@ from sinan_agentic_core.registry.capability_registry import (
     register_capability,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test capability
 # ---------------------------------------------------------------------------
@@ -165,9 +164,7 @@ class TestRegisterCapabilityDecorator:
             assert callable(factory)
             assert factory({}).__class__ is _RecorderCapability
         finally:
-            get_capability_registry()._factories.pop(
-                "test_returns_unchanged", None
-            )
+            get_capability_registry()._factories.pop("test_returns_unchanged", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,9 @@
 """Tests for BaseAgentRunner (core/base_runner.py)."""
 
 import json
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from agents import Usage
 
 from sinan_agentic_core.core.base_runner import BaseAgentRunner, _CollectingSessionWrapper
 from sinan_agentic_core.models.context import AgentContext
@@ -21,10 +20,23 @@ def _registries():
     tool_reg = ToolRegistry()
     guardrail_reg = GuardrailRegistry()
 
-    tool_fn = lambda: "result"
-    tool_reg.register(ToolDefinition(name="test_tool", function=tool_fn, description="desc", category="cat", parameters_description="p", returns_description="r"))
+    def tool_fn():
+        return "result"
 
-    guardrail_fn = lambda: True
+    tool_reg.register(
+        ToolDefinition(
+            name="test_tool",
+            function=tool_fn,
+            description="desc",
+            category="cat",
+            parameters_description="p",
+            returns_description="r",
+        )
+    )
+
+    def guardrail_fn():
+        return True
+
     guardrail_reg.register(GuardrailDefinition("test_guard", "desc", guardrail_fn, "output"))
 
     agent_reg.register(
@@ -48,7 +60,9 @@ def runner(_registries):
     with (
         patch("sinan_agentic_core.core.base_runner.get_agent_registry", return_value=agent_reg),
         patch("sinan_agentic_core.core.base_runner.get_tool_registry", return_value=tool_reg),
-        patch("sinan_agentic_core.core.base_runner.get_guardrail_registry", return_value=guardrail_reg),
+        patch(
+            "sinan_agentic_core.core.base_runner.get_guardrail_registry", return_value=guardrail_reg
+        ),
     ):
         return BaseAgentRunner()
 
@@ -68,8 +82,13 @@ class TestBaseAgentRunnerInit:
     def test_is_not_abstract(self):
         """BaseAgentRunner should be instantiable directly (not ABC)."""
         with (
-            patch("sinan_agentic_core.core.base_runner.get_agent_registry", return_value=AgentRegistry()),
-            patch("sinan_agentic_core.core.base_runner.get_tool_registry", return_value=ToolRegistry()),
+            patch(
+                "sinan_agentic_core.core.base_runner.get_agent_registry",
+                return_value=AgentRegistry(),
+            ),
+            patch(
+                "sinan_agentic_core.core.base_runner.get_tool_registry", return_value=ToolRegistry()
+            ),
             patch(
                 "sinan_agentic_core.core.base_runner.get_guardrail_registry",
                 return_value=GuardrailRegistry(),
@@ -271,10 +290,10 @@ class TestBuildHostedTools:
 
     def test_direct_instance(self, runner):
         # A non-callable instance should be passed through directly
-        mock_tool = "direct_tool_instance"  # str is not callable in _build_hosted_tools context
         # Actually, str IS callable. Use an object that isn't callable.
         class NonCallable:
             pass
+
         obj = NonCallable()
         tools = runner._build_hosted_tools([obj])
         assert len(tools) == 1
@@ -283,6 +302,7 @@ class TestBuildHostedTools:
     def test_factory_error_handled(self, runner):
         def bad_factory():
             raise RuntimeError("broken")
+
         tools = runner._build_hosted_tools([bad_factory])
         assert len(tools) == 0
 
@@ -424,9 +444,7 @@ class TestExecuteStreaming:
             patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
         ):
             mock_runner_cls.run_streamed = Mock(return_value=mock_result)
-            await runner._execute_streamed(
-                "basic_agent", ctx, session, lambda e: None, 30, "hello"
-            )
+            await runner._execute_streamed("basic_agent", ctx, session, lambda e: None, 30, "hello")
             call_kwargs = mock_runner_cls.run_streamed.call_args.kwargs
             assert call_kwargs["max_turns"] == 30
 
@@ -491,9 +509,7 @@ class TestExecuteWithFallback:
         with patch.object(
             runner, "_execute_with_fallback", new_callable=AsyncMock, return_value="fallback"
         ) as m:
-            result = await runner.execute(
-                "basic_agent", ctx, session, fallback_on_overflow=True
-            )
+            result = await runner.execute("basic_agent", ctx, session, fallback_on_overflow=True)
             m.assert_called_once()
             assert result == "fallback"
 
@@ -507,9 +523,7 @@ class TestExecuteWithFallback:
         ):
             mock_runner_cls.run = AsyncMock(side_effect=RuntimeError("Something else broke"))
             with pytest.raises(RuntimeError, match="Something else broke"):
-                await runner._execute_with_fallback(
-                    "basic_agent", ctx, session, 10, "hello", None
-                )
+                await runner._execute_with_fallback("basic_agent", ctx, session, 10, "hello", None)
 
     async def test_fallback_on_max_turns(self, runner):
         """Fallback with str output_type returns raw text."""
@@ -608,9 +622,7 @@ class TestExecuteWithFallback:
             patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
             patch("openai.AsyncOpenAI") as mock_openai,
         ):
-            mock_runner_cls.run = AsyncMock(
-                side_effect=RuntimeError("context_length_exceeded")
-            )
+            mock_runner_cls.run = AsyncMock(side_effect=RuntimeError("context_length_exceeded"))
             mock_client = AsyncMock()
             mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
             mock_openai.return_value = mock_client
@@ -668,16 +680,12 @@ class TestDefaultFallbackPromptBuilder:
         assert "Gathered Context" in prompt
 
     def test_no_tool_outputs(self):
-        prompt = BaseAgentRunner._default_fallback_prompt_builder(
-            "Instructions", [], None
-        )
+        prompt = BaseAgentRunner._default_fallback_prompt_builder("Instructions", [], None)
         assert "no tool outputs collected" in prompt
 
     def test_skips_non_dict_items(self):
         raw_items = ["string_item", 42, None]
-        prompt = BaseAgentRunner._default_fallback_prompt_builder(
-            "Instructions", raw_items, None
-        )
+        prompt = BaseAgentRunner._default_fallback_prompt_builder("Instructions", raw_items, None)
         assert "no tool outputs collected" in prompt
 
 
@@ -713,11 +721,13 @@ class TestPrivateHelpers:
     def test_resolve_output_type_class(self, runner):
         class MyType:
             pass
+
         assert runner._resolve_output_type(MyType) is MyType
 
     def test_resolve_output_type_string(self, runner):
         result = runner._resolve_output_type("ChatResponse")
         from sinan_agentic_core.models.outputs import ChatResponse
+
         assert result is ChatResponse
 
     def test_resolve_output_type_unknown_string(self, runner):
@@ -820,9 +830,7 @@ class TestStructuredAgentAsTool:
 
     async def test_agent_def_as_tool_parameters_default_none(self):
         """AgentDefinition.as_tool_parameters defaults to None."""
-        agent_def = AgentDefinition(
-            name="test", description="test", instructions="test"
-        )
+        agent_def = AgentDefinition(name="test", description="test", instructions="test")
         assert agent_def.as_tool_parameters is None
 
 
@@ -881,9 +889,7 @@ class TestBudgetAwareAgentAsTool:
 
     async def test_agent_def_as_tool_turn_budget_default_none(self):
         """AgentDefinition.as_tool_turn_budget defaults to None."""
-        agent_def = AgentDefinition(
-            name="test", description="test", instructions="test"
-        )
+        agent_def = AgentDefinition(name="test", description="test", instructions="test")
         assert agent_def.as_tool_turn_budget is None
 
 
@@ -895,6 +901,7 @@ class TestBudgetAwareAgentAsTool:
 class TestStructuredToolError:
     def test_returns_json(self):
         from sinan_agentic_core.core.errors import structured_tool_error
+
         result = structured_tool_error(None, ValueError("page_uuid is required"))
         data = json.loads(result)
         assert data["status"] == "error"
@@ -904,24 +911,28 @@ class TestStructuredToolError:
 
     def test_max_turns_hint(self):
         from sinan_agentic_core.core.errors import structured_tool_error
+
         result = structured_tool_error(None, RuntimeError("Max turns exceeded"))
         data = json.loads(result)
         assert "simplify" in data["retry_hint"].lower() or "turns" in data["retry_hint"].lower()
 
     def test_not_found_hint(self):
         from sinan_agentic_core.core.errors import structured_tool_error
+
         result = structured_tool_error(None, ValueError("Page not found: abc-123"))
         data = json.loads(result)
         assert "uuid" in data["retry_hint"].lower()
 
     def test_required_hint(self):
         from sinan_agentic_core.core.errors import structured_tool_error
+
         result = structured_tool_error(None, ValueError("content is required"))
         data = json.loads(result)
         assert "required" in data["retry_hint"].lower()
 
     def test_generic_hint(self):
         from sinan_agentic_core.core.errors import structured_tool_error
+
         result = structured_tool_error(None, RuntimeError("something weird"))
         data = json.loads(result)
         assert "retry" in data["retry_hint"].lower()

--- a/tests/test_instruction_builder.py
+++ b/tests/test_instruction_builder.py
@@ -193,9 +193,11 @@ class TestCallable:
 
 class TestTopLevelImport:
     def test_importable_from_sinan_agentic_core(self):
-        from sinan_agentic_core import InstructionBuilder as IB
-        assert IB is InstructionBuilder
+        import sinan_agentic_core as sac
+
+        assert sac.InstructionBuilder is InstructionBuilder
 
     def test_importable_from_instructions(self):
-        from sinan_agentic_core.instructions import InstructionBuilder as IB
-        assert IB is InstructionBuilder
+        from sinan_agentic_core import instructions
+
+        assert instructions.InstructionBuilder is InstructionBuilder

--- a/tests/test_mcp/test_catalog_mcp.py
+++ b/tests/test_mcp/test_catalog_mcp.py
@@ -2,9 +2,8 @@
 
 import pytest
 
-from sinan_agentic_core.registry.tool_catalog import ToolCatalog
 from sinan_agentic_core.registry.agent_catalog import AgentCatalog
-
+from sinan_agentic_core.registry.tool_catalog import ToolCatalog
 
 # ---------------------------------------------------------------------------
 # ToolCatalog MCP tests
@@ -13,24 +12,26 @@ from sinan_agentic_core.registry.agent_catalog import AgentCatalog
 
 def test_tool_catalog_get_mcp_tools():
     """get_mcp_tools() returns only tools with mcp.expose: true."""
-    catalog = ToolCatalog(raw_tools={
-        "discover": {
-            "description": "Discover",
-            "mcp": {"expose": True},
-        },
-        "search": {
-            "description": "Search",
-            "mcp": {"expose": True},
-        },
-        "think": {
-            "description": "Think",
-            # No mcp section → not exposed
-        },
-        "ask_user": {
-            "description": "Ask user",
-            "mcp": {"expose": False},
-        },
-    })
+    catalog = ToolCatalog(
+        raw_tools={
+            "discover": {
+                "description": "Discover",
+                "mcp": {"expose": True},
+            },
+            "search": {
+                "description": "Search",
+                "mcp": {"expose": True},
+            },
+            "think": {
+                "description": "Think",
+                # No mcp section → not exposed
+            },
+            "ask_user": {
+                "description": "Ask user",
+                "mcp": {"expose": False},
+            },
+        }
+    )
 
     mcp_tools = catalog.get_mcp_tools()
     assert sorted(mcp_tools) == ["discover", "search"]
@@ -38,23 +39,27 @@ def test_tool_catalog_get_mcp_tools():
 
 def test_tool_catalog_get_mcp_tools_empty():
     """get_mcp_tools() returns empty list when no tools have mcp section."""
-    catalog = ToolCatalog(raw_tools={
-        "think": {"description": "Think"},
-    })
+    catalog = ToolCatalog(
+        raw_tools={
+            "think": {"description": "Think"},
+        }
+    )
     assert catalog.get_mcp_tools() == []
 
 
 def test_tool_yaml_entry_mcp_field():
     """ToolYamlEntry should include mcp config when present."""
-    catalog = ToolCatalog(raw_tools={
-        "discover": {
-            "description": "Discover",
-            "mcp": {
-                "expose": True,
-                "annotations": {"readOnlyHint": True},
+    catalog = ToolCatalog(
+        raw_tools={
+            "discover": {
+                "description": "Discover",
+                "mcp": {
+                    "expose": True,
+                    "annotations": {"readOnlyHint": True},
+                },
             },
-        },
-    })
+        }
+    )
 
     entry = catalog.get("discover")
     assert entry.mcp is not None
@@ -64,9 +69,11 @@ def test_tool_yaml_entry_mcp_field():
 
 def test_tool_yaml_entry_no_mcp():
     """ToolYamlEntry.mcp should be None when not present in YAML."""
-    catalog = ToolCatalog(raw_tools={
-        "think": {"description": "Think"},
-    })
+    catalog = ToolCatalog(
+        raw_tools={
+            "think": {"description": "Think"},
+        }
+    )
 
     entry = catalog.get("think")
     assert entry.mcp is None

--- a/tests/test_mcp/test_server_builder.py
+++ b/tests/test_mcp/test_server_builder.py
@@ -1,17 +1,16 @@
 """Tests for MCPServerBuilder — building FastMCP servers from registry."""
 
 import json
-import pytest
 
+import pytest
 from agents import function_tool
 from agents.tool_context import ToolContext
 
-from sinan_agentic_core.registry.tool_registry import ToolRegistry, ToolDefinition
-from sinan_agentic_core.registry.tool_catalog import ToolCatalog
 from sinan_agentic_core.mcp.context_protocol import MCPContextFactory
-from sinan_agentic_core.mcp.yaml_schema import MCPServerConfig
 from sinan_agentic_core.mcp.server_builder import build_mcp_server
-
+from sinan_agentic_core.mcp.yaml_schema import MCPServerConfig
+from sinan_agentic_core.registry.tool_catalog import ToolCatalog
+from sinan_agentic_core.registry.tool_registry import ToolDefinition, ToolRegistry
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -50,32 +49,36 @@ def registry():
     reg = ToolRegistry()
     reg.register(ToolDefinition(name="discover", function=discover, description="Discover"))
     reg.register(ToolDefinition(name="search", function=search, description="Search"))
-    reg.register(ToolDefinition(name="create_page", function=create_page, description="Create page"))
+    reg.register(
+        ToolDefinition(name="create_page", function=create_page, description="Create page")
+    )
     return reg
 
 
 @pytest.fixture
 def catalog():
-    return ToolCatalog(raw_tools={
-        "discover": {
-            "description": "Discover what's available in the graph",
-            "category": "graph_navigation",
-            "mcp": {"expose": True, "annotations": {"readOnlyHint": True}},
-        },
-        "search": {
-            "description": "Search the graph",
-            "category": "graph_navigation",
-            "mcp": {"expose": True, "annotations": {"readOnlyHint": True}},
-        },
-        "create_page": {
-            "description": "Create a new page",
-            "category": "action",
-            "mcp": {
-                "expose": True,
-                "annotations": {"readOnlyHint": False, "destructiveHint": False},
+    return ToolCatalog(
+        raw_tools={
+            "discover": {
+                "description": "Discover what's available in the graph",
+                "category": "graph_navigation",
+                "mcp": {"expose": True, "annotations": {"readOnlyHint": True}},
             },
-        },
-    })
+            "search": {
+                "description": "Search the graph",
+                "category": "graph_navigation",
+                "mcp": {"expose": True, "annotations": {"readOnlyHint": True}},
+            },
+            "create_page": {
+                "description": "Create a new page",
+                "category": "action",
+                "mcp": {
+                    "expose": True,
+                    "annotations": {"readOnlyHint": False, "destructiveHint": False},
+                },
+            },
+        }
+    )
 
 
 @pytest.fixture

--- a/tests/test_mcp/test_tool_adapter.py
+++ b/tests/test_mcp/test_tool_adapter.py
@@ -1,16 +1,14 @@
 """Tests for MCPToolAdapter — tool invocation and handler building."""
 
 import json
-import pytest
-from unittest.mock import AsyncMock
 
+import pytest
 from agents import function_tool
 from agents.tool_context import ToolContext
 
-from sinan_agentic_core.registry.tool_registry import ToolRegistry, ToolDefinition
 from sinan_agentic_core.mcp.context_protocol import MCPContextFactory
 from sinan_agentic_core.mcp.tool_adapter import MCPToolAdapter, _get_params_schema
-
+from sinan_agentic_core.registry.tool_registry import ToolDefinition, ToolRegistry
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -50,16 +48,20 @@ async def search_tool(ctx: ToolContext, query: str, limit: int = 10) -> str:
 @pytest.fixture
 def registry():
     reg = ToolRegistry()
-    reg.register(ToolDefinition(
-        name="discover",
-        function=discover_tool,
-        description="Discover what's available",
-    ))
-    reg.register(ToolDefinition(
-        name="search",
-        function=search_tool,
-        description="Search for things",
-    ))
+    reg.register(
+        ToolDefinition(
+            name="discover",
+            function=discover_tool,
+            description="Discover what's available",
+        )
+    )
+    reg.register(
+        ToolDefinition(
+            name="search",
+            function=search_tool,
+            description="Search for things",
+        )
+    )
     return reg
 
 
@@ -137,6 +139,7 @@ def test_build_mcp_handler_signature(adapter):
     assert handler.__doc__ == "Discover what's available"
 
     import inspect
+
     sig = inspect.signature(handler)
     assert "target" in sig.parameters
     # ctx should NOT appear
@@ -147,6 +150,7 @@ def test_build_mcp_handler_search_signature(adapter):
     handler = adapter.build_mcp_handler("search")
 
     import inspect
+
     sig = inspect.signature(handler)
     params = sig.parameters
     assert "query" in params

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,10 +1,6 @@
 """Tests for output models and context."""
 
-from unittest.mock import Mock
-
 from sinan_agentic_core.models.outputs import ChatResponse, ToolOutput
-from sinan_agentic_core.models.context import AgentContext
-
 
 # -- ToolOutput ---------------------------------------------------------------
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -13,7 +13,9 @@ from sinan_agentic_core.registry.tool_registry import ToolRegistry
 def orchestrator():
     """Build an AgentOrchestrator with empty registries."""
     with (
-        patch("sinan_agentic_core.core.base_runner.get_agent_registry", return_value=AgentRegistry()),
+        patch(
+            "sinan_agentic_core.core.base_runner.get_agent_registry", return_value=AgentRegistry()
+        ),
         patch("sinan_agentic_core.core.base_runner.get_tool_registry", return_value=ToolRegistry()),
         patch(
             "sinan_agentic_core.core.base_runner.get_guardrail_registry",

--- a/tests/test_pluggable_capabilities.py
+++ b/tests/test_pluggable_capabilities.py
@@ -93,7 +93,9 @@ def runner_with_capability_agent():
     with (
         patch("sinan_agentic_core.core.base_runner.get_agent_registry", return_value=agent_reg),
         patch("sinan_agentic_core.core.base_runner.get_tool_registry", return_value=tool_reg),
-        patch("sinan_agentic_core.core.base_runner.get_guardrail_registry", return_value=guardrail_reg),
+        patch(
+            "sinan_agentic_core.core.base_runner.get_guardrail_registry", return_value=guardrail_reg
+        ),
     ):
         from sinan_agentic_core.core.base_runner import BaseAgentRunner
 
@@ -117,8 +119,8 @@ class TestCustomCapabilityIntegration:
             captured_agent["agent"] = kwargs["starting_agent"]
             return mock_result
 
-        with patch("sinan_agentic_core.core.base_runner.Runner") as MockRunner:
-            MockRunner.run = AsyncMock(side_effect=fake_run)
+        with patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls:
+            mock_runner_cls.run = AsyncMock(side_effect=fake_run)
             with patch.object(runner, "create_agent", new_callable=AsyncMock) as mock_create:
                 mock_agent = Mock()
                 mock_agent.tools = []
@@ -175,8 +177,8 @@ class TestCustomCapabilityIntegration:
             captured["agent"] = kwargs["starting_agent"]
             return mock_result
 
-        with patch("sinan_agentic_core.core.base_runner.Runner") as MockRunner:
-            MockRunner.run = AsyncMock(side_effect=fake_run)
+        with patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls:
+            mock_runner_cls.run = AsyncMock(side_effect=fake_run)
             with patch.object(runner, "create_agent", new_callable=AsyncMock) as mock_create:
                 mock_agent = Mock()
                 mock_agent.tools = []
@@ -219,8 +221,8 @@ class TestCapabilityStateIsolation:
             run_cap.llm_starts += 1
             return mock_result
 
-        with patch("sinan_agentic_core.core.base_runner.Runner") as MockRunner:
-            MockRunner.run = AsyncMock(side_effect=fake_run)
+        with patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls:
+            mock_runner_cls.run = AsyncMock(side_effect=fake_run)
             with patch.object(runner, "create_agent", new_callable=AsyncMock) as mock_create:
                 mock_agent = Mock()
                 mock_agent.tools = []

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,9 +3,8 @@
 import pytest
 
 from sinan_agentic_core.registry.agent_registry import AgentDefinition, AgentRegistry
-from sinan_agentic_core.registry.tool_registry import ToolDefinition, ToolRegistry
 from sinan_agentic_core.registry.guardrail_registry import GuardrailDefinition, GuardrailRegistry
-
+from sinan_agentic_core.registry.tool_registry import ToolDefinition, ToolRegistry
 
 # -- AgentDefinition -----------------------------------------------------------
 
@@ -22,7 +21,9 @@ class TestAgentDefinition:
             AgentDefinition(name="bad", description="d")
 
     def test_callable_instructions(self):
-        fn = lambda ctx, agent: "dynamic"
+        def fn(ctx, agent):
+            return "dynamic"
+
         a = AgentDefinition(name="a2", description="d", instructions=fn)
         assert callable(a.instructions)
 
@@ -39,7 +40,9 @@ class TestAgentDefinition:
         assert a.hosted_tools == []
 
     def test_hosted_tools_set(self):
-        factory = lambda: "mock_tool"
+        def factory():
+            return "mock_tool"
+
         a = AgentDefinition(name="a", description="d", instructions="i", hosted_tools=[factory])
         assert len(a.hosted_tools) == 1
         assert a.hosted_tools[0]() == "mock_tool"
@@ -75,7 +78,7 @@ class TestAgentRegistry:
         assert reg.get("x").description == "new"
 
     def test_register_agent_global_helper(self):
-        from sinan_agentic_core.registry.agent_registry import register_agent, get_agent_registry
+        from sinan_agentic_core.registry.agent_registry import get_agent_registry, register_agent
 
         a = AgentDefinition(name="_global_helper_agent", description="d", instructions="i")
         register_agent(a)
@@ -117,8 +120,20 @@ class TestToolRegistry:
 
     def test_get_tool_functions(self):
         reg = ToolRegistry()
-        fn = lambda: "hello"
-        reg.register(ToolDefinition(name="t", function=fn, description="d", category="c", parameters_description="p", returns_description="r"))
+
+        def fn():
+            return "hello"
+
+        reg.register(
+            ToolDefinition(
+                name="t",
+                function=fn,
+                description="d",
+                category="c",
+                parameters_description="p",
+                returns_description="r",
+            )
+        )
         funcs = reg.get_tool_functions(["t", "missing"])
         assert len(funcs) == 1
         assert funcs[0] is fn
@@ -144,7 +159,7 @@ class TestToolRegistry:
 
 class TestRegisterToolDecorator:
     def test_decorator_registers_and_returns_function(self):
-        from sinan_agentic_core.registry.tool_registry import register_tool, get_tool_registry
+        from sinan_agentic_core.registry.tool_registry import get_tool_registry, register_tool
 
         @register_tool(
             name="_deco_tool",
@@ -196,7 +211,10 @@ class TestGuardrailRegistry:
 
     def test_get_guardrail_functions(self):
         reg = GuardrailRegistry()
-        fn = lambda: "check"
+
+        def fn():
+            return "check"
+
         reg.register(GuardrailDefinition("g", "d", fn, "input"))
         funcs = reg.get_guardrail_functions(["g", "missing"])
         assert len(funcs) == 1
@@ -204,8 +222,13 @@ class TestGuardrailRegistry:
 
     def test_get_all_functions(self):
         reg = GuardrailRegistry()
-        fn1 = lambda: 1
-        fn2 = lambda: 2
+
+        def fn1():
+            return 1
+
+        def fn2():
+            return 2
+
         reg.register(GuardrailDefinition("a", "d", fn1, "input"))
         reg.register(GuardrailDefinition("b", "d", fn2, "output"))
         all_fns = reg.get_all_functions()
@@ -225,8 +248,8 @@ class TestRegisterGuardrailDecorator:
 
     def test_decorator_registers_and_returns_function(self):
         from sinan_agentic_core.registry.guardrail_registry import (
-            register_guardrail,
             get_guardrail_registry,
+            register_guardrail,
         )
 
         @register_guardrail(
@@ -256,9 +279,19 @@ class TestAgentFactory:
         from sinan_agentic_core.registry.tool_registry import get_tool_registry
 
         tool_reg = get_tool_registry()
-        tool_fn = lambda: None
+
+        def tool_fn():
+            return None
+
         tool_reg.register(
-            ToolDefinition(name="_factory_tool", function=tool_fn, description="desc", category="cat", parameters_description="p", returns_description="r")
+            ToolDefinition(
+                name="_factory_tool",
+                function=tool_fn,
+                description="desc",
+                category="cat",
+                parameters_description="p",
+                returns_description="r",
+            )
         )
 
         get_agent_registry().register(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3,8 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
-import pytest
-
+from sinan_agentic_core.services.chat import _usage_to_dict
 from sinan_agentic_core.services.events import (
     AgentCompleteEvent,
     AgentStartEvent,
@@ -17,9 +16,7 @@ from sinan_agentic_core.services.events import (
     ToolCallEvent,
 )
 from sinan_agentic_core.services.hooks import StreamingRunHooks
-from sinan_agentic_core.services.chat import _usage_to_dict
 from sinan_agentic_core.session.agent_session import AgentSession
-
 
 # -- Event dataclasses ---------------------------------------------------------
 
@@ -202,9 +199,9 @@ class TestChat:
     @staticmethod
     def _get_chat_module():
         import sys
+
         # Import to ensure the module is loaded, then get from sys.modules
         # to avoid the __init__.py shadowing the module with the function
-        import sinan_agentic_core.services.chat  # noqa: F811
         return sys.modules["sinan_agentic_core.services.chat"]
 
     async def test_chat_returns_usage(self):
@@ -227,9 +224,7 @@ class TestChat:
             with patch.object(chat_mod, "Runner") as mock_runner:
                 mock_runner.run = AsyncMock(return_value=mock_result)
 
-                result = await chat_mod.chat(
-                    "Hi", agent_name="test_agent", session=session
-                )
+                result = await chat_mod.chat("Hi", agent_name="test_agent", session=session)
 
         assert result["success"] is True
         assert result["response"] == "Hello!"
@@ -245,9 +240,7 @@ class TestChat:
         with patch.object(chat_mod, "create_agent_from_registry") as mock_factory:
             mock_factory.side_effect = ValueError("Agent not found")
 
-            result = await chat_mod.chat(
-                "Hi", agent_name="missing", session=session
-            )
+            result = await chat_mod.chat("Hi", agent_name="missing", session=session)
 
         assert result["success"] is False
         assert "Agent not found" in result["error"]
@@ -272,9 +265,7 @@ class TestChat:
             with patch.object(chat_mod, "Runner") as mock_runner:
                 mock_runner.run = AsyncMock(return_value=mock_result)
 
-                result = await chat_mod.chat(
-                    "Hi", agent_name="a", session=session, context=Mock()
-                )
+                result = await chat_mod.chat("Hi", agent_name="a", session=session, context=Mock())
 
         assert result["success"] is True
         # Verify context was forwarded to Runner.run
@@ -289,7 +280,7 @@ class TestChatWithHooks:
     @staticmethod
     def _get_chat_module():
         import sys
-        import sinan_agentic_core.services.chat  # noqa: F811
+
         return sys.modules["sinan_agentic_core.services.chat"]
 
     async def test_yields_thinking_and_answer(self):
@@ -387,7 +378,7 @@ class TestChatStreamed:
     @staticmethod
     def _get_chat_module():
         import sys
-        import sinan_agentic_core.services.chat  # noqa: F811
+
         return sys.modules["sinan_agentic_core.services.chat"]
 
     async def test_yields_stream_events(self):
@@ -517,9 +508,7 @@ class TestChatStreamed:
             mock_factory.side_effect = RuntimeError("Stream failed")
 
             events = []
-            async for event in chat_mod.chat_streamed(
-                "Hi", agent_name="missing", session=session
-            ):
+            async for event in chat_mod.chat_streamed("Hi", agent_name="missing", session=session):
                 events.append(event)
 
         assert any(e["event"] == "error" for e in events)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,7 +8,6 @@ from sinan_agentic_core.core.turn_budget import TurnBudget
 from sinan_agentic_core.session.agent_session import AgentSession, ConversationHistory
 from sinan_agentic_core.session.sqlite_store import SQLiteSessionStore
 
-
 # -- ConversationHistory -------------------------------------------------------
 
 
@@ -49,21 +48,25 @@ class TestAgentSession:
         assert items[0]["content"] == "Hello"
 
     async def test_get_items_with_limit(self, session):
-        await session.add_items([
-            {"role": "user", "content": "msg1"},
-            {"role": "assistant", "content": "msg2"},
-            {"role": "user", "content": "msg3"},
-        ])
+        await session.add_items(
+            [
+                {"role": "user", "content": "msg1"},
+                {"role": "assistant", "content": "msg2"},
+                {"role": "user", "content": "msg3"},
+            ]
+        )
         items = await session.get_items(limit=2)
         assert len(items) == 2
         assert items[0]["content"] == "msg2"
 
     async def test_skips_empty_content(self, session):
-        await session.add_items([
-            {"role": "user", "content": ""},
-            {"role": "user", "content": "   "},
-            {"role": "user", "content": "valid"},
-        ])
+        await session.add_items(
+            [
+                {"role": "user", "content": ""},
+                {"role": "user", "content": "   "},
+                {"role": "user", "content": "valid"},
+            ]
+        )
         items = await session.get_items()
         assert len(items) == 1
         assert items[0]["content"] == "valid"
@@ -105,20 +108,26 @@ class TestAgentSession:
         assert isinstance(h, ConversationHistory)
 
     async def test_add_items_with_name_and_tool_call_id(self, session):
-        await session.add_items([
-            {"role": "assistant", "content": "hi", "name": "bot"},
-            {"role": "tool", "content": "result", "tool_call_id": "tc_123"},
-        ])
+        await session.add_items(
+            [
+                {"role": "assistant", "content": "hi", "name": "bot"},
+                {"role": "tool", "content": "result", "tool_call_id": "tc_123"},
+            ]
+        )
         items = await session.get_items()
         assert items[0]["name"] == "bot"
         assert items[1]["tool_call_id"] == "tc_123"
 
     async def test_structured_output_cleanup(self, session):
         """SDK returns structured output as list of dicts — session should extract text."""
-        await session.add_items([{
-            "role": "assistant",
-            "content": [{"text": '{"response": "parsed answer"}', "type": "output_text"}],
-        }])
+        await session.add_items(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"text": '{"response": "parsed answer"}', "type": "output_text"}],
+                }
+            ]
+        )
         items = await session.get_items()
         assert len(items) == 1
         assert '"parsed answer"' in items[0]["content"]
@@ -292,6 +301,7 @@ class TestAgentSessionRehydrate:
         tool = Mock()
         tool.name = "search"
         import json as _json
+
         original.on_tool_start(ctx, tool, _json.dumps({"q": "x"}))
         original.on_tool_end(ctx, tool, _json.dumps({"error": "boom"}))
 

--- a/tests/test_tool_catalog.py
+++ b/tests/test_tool_catalog.py
@@ -12,7 +12,6 @@ from sinan_agentic_core.registry.tool_catalog import (
 )
 from sinan_agentic_core.registry.tool_registry import ToolDefinition, ToolRegistry
 
-
 # ---------------------------------------------------------------------------
 # ToolYamlEntry
 # ---------------------------------------------------------------------------
@@ -47,9 +46,11 @@ class TestToolYamlEntry:
 
 class TestToolCatalog:
     def test_get_existing_tool(self):
-        catalog = ToolCatalog(raw_tools={
-            "search": {"description": "Search stuff", "category": "graph"},
-        })
+        catalog = ToolCatalog(
+            raw_tools={
+                "search": {"description": "Search stuff", "category": "graph"},
+            }
+        )
         entry = catalog.get("search")
         assert entry.description == "Search stuff"
         assert entry.category == "graph"
@@ -60,10 +61,12 @@ class TestToolCatalog:
             catalog.get("missing_tool")
 
     def test_list_tools(self):
-        catalog = ToolCatalog(raw_tools={
-            "search": {"description": "a"},
-            "read": {"description": "b"},
-        })
+        catalog = ToolCatalog(
+            raw_tools={
+                "search": {"description": "a"},
+                "read": {"description": "b"},
+            }
+        )
         assert set(catalog.list_tools()) == {"search", "read"}
 
     def test_empty_catalog(self):
@@ -86,16 +89,16 @@ class TestEnrichRegistry:
 
     def test_yaml_overwrites_empty_decorator_fields(self):
         """YAML fills in metadata that the decorator left empty."""
-        reg = self._make_registry(
-            ToolDefinition(name="search", function=lambda: None)
+        reg = self._make_registry(ToolDefinition(name="search", function=lambda: None))
+        catalog = ToolCatalog(
+            raw_tools={
+                "search": {
+                    "description": "Search the graph",
+                    "category": "graph_nav",
+                    "recovery_hint": "Try broader terms",
+                },
+            }
         )
-        catalog = ToolCatalog(raw_tools={
-            "search": {
-                "description": "Search the graph",
-                "category": "graph_nav",
-                "recovery_hint": "Try broader terms",
-            },
-        })
         catalog.enrich_registry(reg)
 
         tool = reg.get_tool("search")
@@ -113,9 +116,11 @@ class TestEnrichRegistry:
                 category="old_cat",
             )
         )
-        catalog = ToolCatalog(raw_tools={
-            "search": {"description": "new desc", "category": "new_cat"},
-        })
+        catalog = ToolCatalog(
+            raw_tools={
+                "search": {"description": "new desc", "category": "new_cat"},
+            }
+        )
         catalog.enrich_registry(reg)
 
         tool = reg.get_tool("search")
@@ -132,9 +137,11 @@ class TestEnrichRegistry:
                 category="decorator_cat",
             )
         )
-        catalog = ToolCatalog(raw_tools={
-            "search": {"description": "", "category": ""},
-        })
+        catalog = ToolCatalog(
+            raw_tools={
+                "search": {"description": "", "category": ""},
+            }
+        )
         catalog.enrich_registry(reg)
 
         tool = reg.get_tool("search")
@@ -144,9 +151,11 @@ class TestEnrichRegistry:
     def test_tool_in_yaml_not_in_registry_logs_warning(self, caplog):
         """YAML tool with no registered function logs warning."""
         reg = self._make_registry()  # empty registry
-        catalog = ToolCatalog(raw_tools={
-            "unknown_tool": {"description": "No function registered"},
-        })
+        catalog = ToolCatalog(
+            raw_tools={
+                "unknown_tool": {"description": "No function registered"},
+            }
+        )
         with caplog.at_level("WARNING"):
             catalog.enrich_registry(reg)
         assert "unknown_tool" in caplog.text
@@ -171,13 +180,16 @@ class TestEnrichRegistry:
 
     def test_function_reference_preserved(self):
         """enrich_registry never touches the function reference."""
-        fn = lambda: "hello"
-        reg = self._make_registry(
-            ToolDefinition(name="t", function=fn)
+
+        def fn():
+            return "hello"
+
+        reg = self._make_registry(ToolDefinition(name="t", function=fn))
+        catalog = ToolCatalog(
+            raw_tools={
+                "t": {"description": "enriched"},
+            }
         )
-        catalog = ToolCatalog(raw_tools={
-            "t": {"description": "enriched"},
-        })
         catalog.enrich_registry(reg)
         assert reg.get_tool("t").function is fn
 
@@ -187,10 +199,12 @@ class TestEnrichRegistry:
             ToolDefinition(name="a", function=lambda: None),
             ToolDefinition(name="b", function=lambda: None),
         )
-        catalog = ToolCatalog(raw_tools={
-            "a": {"description": "tool a", "category": "cat_a"},
-            "b": {"description": "tool b", "category": "cat_b"},
-        })
+        catalog = ToolCatalog(
+            raw_tools={
+                "a": {"description": "tool a", "category": "cat_a"},
+                "b": {"description": "tool b", "category": "cat_b"},
+            }
+        )
         catalog.enrich_registry(reg)
 
         assert reg.get_tool("a").description == "tool a"
@@ -254,7 +268,9 @@ class TestLoadToolCatalog:
         yaml_file = tmp_path / "tools.yaml"
         yaml_file.write_text(yaml_content)
 
-        fn = lambda: "result"
+        def fn():
+            return "result"
+
         reg = ToolRegistry()
         reg.register(ToolDefinition(name="my_tool", function=fn))
 
@@ -278,12 +294,14 @@ class TestLoadToolCatalog:
 class TestTopLevelImports:
     def test_import_from_registry_package(self):
         from sinan_agentic_core.registry import ToolCatalog, ToolYamlEntry, load_tool_catalog
+
         assert ToolCatalog is not None
         assert ToolYamlEntry is not None
         assert load_tool_catalog is not None
 
     def test_import_from_top_level(self):
         from sinan_agentic_core import ToolCatalog, ToolYamlEntry, load_tool_catalog
+
         assert ToolCatalog is not None
         assert ToolYamlEntry is not None
         assert load_tool_catalog is not None

--- a/tests/test_tool_error_recovery.py
+++ b/tests/test_tool_error_recovery.py
@@ -8,10 +8,8 @@ from agents import RunContextWrapper
 
 from sinan_agentic_core.core.capabilities import Capability
 from sinan_agentic_core.core.tool_error_recovery import (
-    ToolErrorEntry,
     ToolErrorRecovery,
 )
-
 
 # ------------------------------------------------------------------ #
 # ToolErrorRecovery — basic tracking
@@ -81,9 +79,7 @@ class TestRecordToolResult:
 
     def test_status_failed_without_message_uses_fallback(self):
         recovery = ToolErrorRecovery()
-        recovery.record_tool_result(
-            "my_tool", json.dumps({"status": "failed"})
-        )
+        recovery.record_tool_result("my_tool", json.dumps({"status": "failed"}))
         assert recovery.has_errors
         summary = recovery.get_error_summary()
         assert "failed" in summary["my_tool"]["error"]
@@ -101,13 +97,9 @@ class TestRecordToolResult:
 
     def test_status_failed_clears_on_subsequent_success(self):
         recovery = ToolErrorRecovery()
-        recovery.record_tool_result(
-            "my_tool", json.dumps({"status": "failed", "message": "bad"})
-        )
+        recovery.record_tool_result("my_tool", json.dumps({"status": "failed", "message": "bad"}))
         assert recovery.has_errors
-        recovery.record_tool_result(
-            "my_tool", json.dumps({"status": "completed", "message": "ok"})
-        )
+        recovery.record_tool_result("my_tool", json.dumps({"status": "completed", "message": "ok"}))
         assert not recovery.has_errors
 
     def test_multiple_errors_same_tool(self):
@@ -121,12 +113,8 @@ class TestRecordToolResult:
 
     def test_different_args_resets_identical_count(self):
         recovery = ToolErrorRecovery()
-        recovery.record_tool_result(
-            "my_tool", json.dumps({"error": "fail"}), json.dumps({"a": 1})
-        )
-        recovery.record_tool_result(
-            "my_tool", json.dumps({"error": "fail"}), json.dumps({"a": 2})
-        )
+        recovery.record_tool_result("my_tool", json.dumps({"error": "fail"}), json.dumps({"a": 1}))
+        recovery.record_tool_result("my_tool", json.dumps({"error": "fail"}), json.dumps({"a": 2}))
         summary = recovery.get_error_summary()
         assert summary["my_tool"]["call_count"] == 2
         assert summary["my_tool"]["identical_count"] == 1  # reset because args differ
@@ -398,8 +386,8 @@ class TestBaseAgentRunnerIntegration:
     @pytest.fixture
     def _registries(self):
         from sinan_agentic_core.registry.agent_registry import AgentDefinition, AgentRegistry
-        from sinan_agentic_core.registry.tool_registry import ToolRegistry
         from sinan_agentic_core.registry.guardrail_registry import GuardrailRegistry
+        from sinan_agentic_core.registry.tool_registry import ToolRegistry
 
         agent_reg = AgentRegistry()
         tool_reg = ToolRegistry()
@@ -423,7 +411,10 @@ class TestBaseAgentRunnerIntegration:
         with (
             patch("sinan_agentic_core.core.base_runner.get_agent_registry", return_value=agent_reg),
             patch("sinan_agentic_core.core.base_runner.get_tool_registry", return_value=tool_reg),
-            patch("sinan_agentic_core.core.base_runner.get_guardrail_registry", return_value=guardrail_reg),
+            patch(
+                "sinan_agentic_core.core.base_runner.get_guardrail_registry",
+                return_value=guardrail_reg,
+            ),
         ):
             return BaseAgentRunner()
 
@@ -466,6 +457,7 @@ class TestBaseAgentRunnerIntegration:
 
     def test_build_hooks_none_when_no_capabilities(self):
         from sinan_agentic_core.core.base_runner import BaseAgentRunner
+
         assert BaseAgentRunner._build_hooks([]) is None
 
     def test_build_hooks_returns_composite(self):
@@ -493,8 +485,8 @@ class TestBaseAgentRunnerIntegration:
         mock_result = Mock()
         mock_result.final_output = "test output"
 
-        with patch("sinan_agentic_core.core.base_runner.Runner") as MockRunner:
-            MockRunner.run = AsyncMock(return_value=mock_result)
+        with patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls:
+            mock_runner_cls.run = AsyncMock(return_value=mock_result)
             with patch.object(runner, "create_agent", new_callable=AsyncMock) as mock_create:
                 mock_agent = Mock()
                 mock_agent.tools = []
@@ -502,12 +494,16 @@ class TestBaseAgentRunnerIntegration:
                 mock_create.return_value = mock_agent
 
                 result = await runner._execute_basic(
-                    "test_agent", context, session, 10, "hello",
+                    "test_agent",
+                    context,
+                    session,
+                    10,
+                    "hello",
                     capabilities=[recovery],
                 )
 
                 assert result == "test output"
-                call_kwargs = MockRunner.run.call_args[1]
+                call_kwargs = mock_runner_cls.run.call_args[1]
                 assert isinstance(call_kwargs["hooks"], _CompositeHooks)
 
     @pytest.mark.asyncio
@@ -520,7 +516,9 @@ class TestBaseAgentRunnerIntegration:
         with patch.object(runner, "_execute_basic", new_callable=AsyncMock) as mock_basic:
             mock_basic.return_value = "output"
             await runner.execute(
-                "test_agent", context, session=Mock(),
+                "test_agent",
+                context,
+                session=Mock(),
                 input_text="hello",
                 error_recovery=recovery,
             )
@@ -574,10 +572,12 @@ class TestCompositeHooks:
 class TestTopLevelImports:
     def test_importable_from_core(self):
         from sinan_agentic_core.core import ToolErrorRecovery
+
         assert ToolErrorRecovery is not None
 
     def test_importable_from_top_level(self):
         from sinan_agentic_core import ToolErrorRecovery
+
         assert ToolErrorRecovery is not None
 
 
@@ -715,7 +715,9 @@ class TestResetClearsPendingArgs:
 # ------------------------------------------------------------------ #
 
 
-def _record_failure(recovery: ToolErrorRecovery, tool_name: str, args: dict, message: str = "boom") -> None:
+def _record_failure(
+    recovery: ToolErrorRecovery, tool_name: str, args: dict, message: str = "boom"
+) -> None:
     """Helper: simulate a single failed tool call."""
     ctx = RunContextWrapper(context=None)
     tool = Mock()

--- a/tests/test_turn_budget.py
+++ b/tests/test_turn_budget.py
@@ -1,13 +1,12 @@
 """Tests for the turn budget system (core/turn_budget.py + turn_budget_tool.py)."""
 
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from agents import RunContextWrapper
 
 from sinan_agentic_core.core.capabilities import Capability
 from sinan_agentic_core.core.turn_budget import TurnBudget
-
 
 # ------------------------------------------------------------------ #
 # TurnBudget dataclass
@@ -30,7 +29,9 @@ class TestTurnBudgetDefaults:
         assert budget.extension_reasons == []
 
     def test_custom_values(self):
-        budget = TurnBudget(default_turns=5, reminder_at=1, max_extensions=2, extension_size=3, absolute_max=15)
+        budget = TurnBudget(
+            default_turns=5, reminder_at=1, max_extensions=2, extension_size=3, absolute_max=15
+        )
         assert budget.default_turns == 5
         assert budget.absolute_max == 15
 
@@ -178,7 +179,9 @@ class TestBuildInstructionSection:
         assert "5 of 10" in section
 
     def test_warning_with_extension_available(self):
-        budget = TurnBudget(default_turns=10, reminder_at=2, max_extensions=1, extension_size=5, absolute_max=20)
+        budget = TurnBudget(
+            default_turns=10, reminder_at=2, max_extensions=1, extension_size=5, absolute_max=20
+        )
         budget.turns_used = 9
         section = budget.build_instruction_section()
         assert "1 turn(s) remaining" in section
@@ -241,6 +244,7 @@ class TestTurnBudgetOnLlmStart:
 class TestInstructionBuilderTurnBudget:
     def test_no_budget_returns_none(self):
         from sinan_agentic_core.instructions import InstructionBuilder
+
         builder = InstructionBuilder(None, None)
         assert builder.turn_budget_section() is None
 
@@ -295,8 +299,8 @@ class TestBaseAgentRunnerTurnBudget:
     @pytest.fixture
     def _registries(self):
         from sinan_agentic_core.registry.agent_registry import AgentDefinition, AgentRegistry
-        from sinan_agentic_core.registry.tool_registry import ToolRegistry
         from sinan_agentic_core.registry.guardrail_registry import GuardrailRegistry
+        from sinan_agentic_core.registry.tool_registry import ToolRegistry
 
         agent_reg = AgentRegistry()
         tool_reg = ToolRegistry()
@@ -320,7 +324,10 @@ class TestBaseAgentRunnerTurnBudget:
         with (
             patch("sinan_agentic_core.core.base_runner.get_agent_registry", return_value=agent_reg),
             patch("sinan_agentic_core.core.base_runner.get_tool_registry", return_value=tool_reg),
-            patch("sinan_agentic_core.core.base_runner.get_guardrail_registry", return_value=guardrail_reg),
+            patch(
+                "sinan_agentic_core.core.base_runner.get_guardrail_registry",
+                return_value=guardrail_reg,
+            ),
         ):
             return BaseAgentRunner()
 
@@ -360,8 +367,8 @@ class TestBaseAgentRunnerTurnBudget:
         mock_result = Mock()
         mock_result.final_output = "test output"
 
-        with patch("sinan_agentic_core.core.base_runner.Runner") as MockRunner:
-            MockRunner.run = AsyncMock(return_value=mock_result)
+        with patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls:
+            mock_runner_cls.run = AsyncMock(return_value=mock_result)
             with patch.object(runner, "create_agent", new_callable=AsyncMock) as mock_create:
                 mock_agent = Mock()
                 mock_agent.tools = []
@@ -369,13 +376,17 @@ class TestBaseAgentRunnerTurnBudget:
                 mock_create.return_value = mock_agent
 
                 result = await runner._execute_basic(
-                    "test_agent", context, session, 25, "hello",
+                    "test_agent",
+                    context,
+                    session,
+                    25,
+                    "hello",
                     capabilities=[budget],
                 )
 
                 assert result == "test output"
                 # Verify hooks were passed
-                call_kwargs = MockRunner.run.call_args[1]
+                call_kwargs = mock_runner_cls.run.call_args[1]
                 assert isinstance(call_kwargs["hooks"], _CompositeHooks)
                 assert call_kwargs["max_turns"] == 25
 
@@ -388,7 +399,9 @@ class TestBaseAgentRunnerTurnBudget:
         with patch.object(runner, "_execute_basic", new_callable=AsyncMock) as mock_basic:
             mock_basic.return_value = "output"
             await runner.execute(
-                "test_agent", context, session,
+                "test_agent",
+                context,
+                session,
                 max_turns=10,
                 input_text="hello",
                 turn_budget=budget,
@@ -407,7 +420,9 @@ class TestBaseAgentRunnerTurnBudget:
         with patch.object(runner, "_execute_basic", new_callable=AsyncMock) as mock_basic:
             mock_basic.return_value = "output"
             await runner.execute(
-                "test_agent", context, session=Mock(),
+                "test_agent",
+                context,
+                session=Mock(),
                 input_text="hello",
                 turn_budget=budget,
             )
@@ -425,7 +440,9 @@ class TestBaseAgentRunnerTurnBudget:
         with patch.object(runner, "_execute_basic", new_callable=AsyncMock) as mock_basic:
             mock_basic.return_value = "output"
             await runner.execute(
-                "test_agent", context, session=Mock(),
+                "test_agent",
+                context,
+                session=Mock(),
                 input_text="hello",
                 turn_budget=budget,
             )
@@ -441,7 +458,9 @@ class TestBaseAgentRunnerTurnBudget:
         with patch.object(runner, "_execute_basic", new_callable=AsyncMock) as mock_basic:
             mock_basic.return_value = "output"
             await runner.execute(
-                "test_agent", context, session,
+                "test_agent",
+                context,
+                session,
                 max_turns=15,
                 input_text="hello",
             )
@@ -485,6 +504,7 @@ class TestTurnBudgetIsCapability:
 
     def test_tools_returns_request_extension(self):
         from sinan_agentic_core.core.turn_budget_tool import request_extension_tool
+
         assert TurnBudget().tools() == [request_extension_tool]
 
 
@@ -599,6 +619,7 @@ class TestTurnBudgetSnapshot:
 
     def test_snapshot_is_json_serializable(self):
         import json
+
         budget = TurnBudget()
         budget.record_turn()
         budget.request_extension("why")
@@ -613,8 +634,10 @@ class TestTurnBudgetSnapshot:
 class TestTopLevelImports:
     def test_turn_budget_importable(self):
         from sinan_agentic_core import TurnBudget
+
         assert TurnBudget is not None
 
     def test_turn_budget_from_core(self):
         from sinan_agentic_core.core import TurnBudget
+
         assert TurnBudget is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1504,7 +1504,7 @@ wheels = [
 
 [[package]]
 name = "sinan-agentic-core"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },

--- a/uv.lock
+++ b/uv.lock
@@ -1522,6 +1522,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 mcp = [
     { name = "mcp" },
@@ -1541,6 +1542,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
 provides-extras = ["mcp", "dev"]
 
@@ -1643,6 +1645,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #20

## Summary
Cleans up the ruff lint violations that surfaced after CI was wired up in #18, so `ruff check .` runs clean across the codebase.

- Resolves all outstanding ruff findings (53 files touched in the impl run)
- Bumps package version to 0.9.0 and syncs `uv.lock` accordingly
- Closes #20

## Test plan
- [x] `ruff check .` passes
- [x] `black --check .` passes
- [x] `pytest` passes with coverage gate
- [x] `mypy sinan_agentic_core` passes
- [ ] Reviewer: confirm CI is green on the PR