### PR TITLE
feat(core): add ToolTracer capability for non-streaming observability (closes #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A framework for building AI agents using the OpenAI Agents SDK. Fork this reposi
 - **Tool Catalog** - Load tool metadata (description, category, recovery hints) from a YAML file
 - **Knowledge Store** - Inject domain knowledge from YAML files into agent system prompts
 - **Structured Agent-as-Tool** - Typed input schemas and structured error handling for sub-agent calls
-- **Capabilities** - Pluggable agent behaviors (turn budgets, error recovery, custom hooks) - write a `Capability` subclass and attach it to an `AgentDefinition`. See [`documentation/project/capabilities.md`](documentation/project/capabilities.md).
+- **Capabilities** - Pluggable agent behaviors (turn budgets, error recovery, tool tracing, custom hooks) - write a `Capability` subclass and attach it to an `AgentDefinition`. See [`documentation/project/capabilities.md`](documentation/project/capabilities.md).
 - **MCP Server** - Expose registered tools as an MCP server (stdio or HTTP) with zero description duplication - all metadata comes from `tools.yaml`
 
 ## Installation
@@ -676,7 +676,7 @@ No manual wiring needed - just set `as_tool_parameters` on your `AgentDefinition
 
 ## Extending sinan-agentic — Custom Capabilities
 
-`Capability` is the extension point for cross-cutting agent behavior. Write a subclass, attach it to an `AgentDefinition`, and the runtime calls its lifecycle hooks (and merges its instruction fragments into the system prompt) for every run. Both `TurnBudget` and `ToolErrorRecovery` are themselves `Capability` subclasses - see them for reference.
+`Capability` is the extension point for cross-cutting agent behavior. Write a subclass, attach it to an `AgentDefinition`, and the runtime calls its lifecycle hooks (and merges its instruction fragments into the system prompt) for every run. `TurnBudget`, `ToolErrorRecovery`, and `ToolTracer` are themselves `Capability` subclasses - see them for reference.
 
 ```python
 from agents import RunContextWrapper, Tool
@@ -823,6 +823,74 @@ After repeated identical failures:
 | `tool_registry` | None | ToolRegistry for looking up `recovery_hint` |
 | `mcp_hints` | `{}` | Dict mapping MCP tool names to hint strings |
 | `max_identical_before_stop` | 3 | Stop threshold for identical-argument retries |
+
+## Tool Tracer (Non-Streaming Observability)
+
+The streaming path emits per-tool events through `on_event`, but non-streaming runs (`streaming=False`, the default) have no equivalent channel. `ToolTracer` is a built-in `Capability` that prints one line per tool call and agent boundary, so non-streaming consumers can see what the agent is doing without leaving the framework or reading `session.history` after the fact.
+
+### Usage
+
+Attach it like any other capability — declarative on the agent, or runtime through `execute()`:
+
+```python
+from sinan_agentic_core import AgentDefinition, ToolTracer, register_agent
+
+register_agent(AgentDefinition(
+    name="research_agent",
+    description="Reads papers and summarizes findings",
+    instructions="...",
+    tools=["search_papers", "fetch_url"],
+    capabilities=[ToolTracer()],
+))
+```
+
+Or pass a custom sink (any `Callable[[str], None]`) — for example, a logger:
+
+```python
+import logging
+
+logger = logging.getLogger("agent.trace")
+tracer = ToolTracer(sink=logger.info, truncate_args=120, truncate_result=300)
+```
+
+Each run emits lines such as:
+
+```text
+[agent start] research_agent
+[tool start] search_papers args={"query": "transformer scaling laws"}
+[tool end] search_papers result=[{"id": "2401.12345", ...
+[agent end] research_agent
+```
+
+### YAML
+
+The `tool_tracer` factory is pre-registered in `CapabilityRegistry`, so YAML agents can opt in with no Python:
+
+```yaml
+agents:
+  research_agent:
+    model: gpt-4o
+    description: Reads papers and summarizes findings
+    capabilities:
+      - name: tool_tracer
+        config:
+          truncate_args: 120
+          truncate_result: 300
+          include_timestamps: true
+```
+
+`sink` is not configurable from YAML — it falls back to `print`. To pipe trace lines into a logger, attach the tracer in code instead.
+
+### Configuration reference
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `sink` | `print` | One-arg callable receiving each line |
+| `truncate_args` | `200` | Maximum length of the rendered `args` string (`0` disables) |
+| `truncate_result` | `500` | Maximum length of the rendered `result` string (`0` disables) |
+| `include_timestamps` | `False` | Prepend `HH:MM:SS.mmm` wall-clock prefix to every line |
+
+`ToolTracer` is observation-only and never mutates state used by the agent, so it composes cleanly with `TurnBudget` and `ToolErrorRecovery` on the same agent.
 
 ## Turn Budget (Soft Turn Management)
 
@@ -1022,6 +1090,7 @@ sinan_agentic_core/
 │   │   └── base.py               # Capability base class + lifecycle hooks
 │   ├── errors.py                 # structured_tool_error for agent-as-tool failures
 │   ├── tool_error_recovery.py    # ToolErrorRecovery capability
+│   ├── tool_tracer.py            # ToolTracer capability (non-streaming tool-call tracing)
 │   ├── turn_budget.py            # TurnBudget capability + TurnBudgetHooks
 │   └── turn_budget_tool.py       # request_extension tool (agent self-approval)
 ├── instructions/

--- a/documentation/project/capabilities.md
+++ b/documentation/project/capabilities.md
@@ -235,10 +235,14 @@ The runner merges both sources into a single effective list, calls
 |---|---|
 | `TurnBudget` | Soft turn budget with self-extension. Counts turns via `on_llm_start`, injects budget status via `instructions`, exposes `request_extension` via `tools()`. |
 | `ToolErrorRecovery` | Tracks tool errors, detects repeated identical calls, injects progressive recovery guidance via `instructions`. |
+| `ToolTracer` | Observation-only tracer for non-streaming runs. Emits one line per `on_agent_start` / `on_agent_end` / `on_tool_start` / `on_tool_end` to a configurable `sink` (default `print`), with independent `truncate_args` / `truncate_result` limits and optional wall-clock timestamps. |
 
-Both are first-class `Capability` subclasses. The README sections on
+All three are first-class `Capability` subclasses. The README sections on
 [Turn Budget](../../README.md#turn-budget-soft-turn-management) and
 [Tool Error Recovery](../../README.md#tool-error-recovery) cover usage.
+`ToolTracer` is the recommended built-in for non-streaming observability —
+the streaming path already exposes tool-call events through `on_event`, so
+streaming consumers should keep using that channel.
 
 ## Migration notes
 

--- a/sinan_agentic_core/__init__.py
+++ b/sinan_agentic_core/__init__.py
@@ -37,7 +37,7 @@ Quick Start:
     )
 """
 
-from .core import BaseAgentRunner, Capability, ToolErrorRecovery, TurnBudget
+from .core import BaseAgentRunner, Capability, ToolErrorRecovery, ToolTracer, TurnBudget
 from .instructions import InstructionBuilder
 from .llm import (
     AzureOpenAIProviderConfig,
@@ -91,6 +91,7 @@ __all__ = [
     "BaseAgentRunner",
     "Capability",
     "ToolErrorRecovery",
+    "ToolTracer",
     "TurnBudget",
     # Instructions
     "InstructionBuilder",

--- a/sinan_agentic_core/core/__init__.py
+++ b/sinan_agentic_core/core/__init__.py
@@ -5,12 +5,14 @@ This module contains fundamental components for agent execution:
 - Capability: Pluggable agent behavior primitive
 - TurnBudget: Soft turn budget with self-extension (Capability)
 - ToolErrorRecovery: Intelligent tool error tracking (Capability)
+- ToolTracer: Observation-only tool-call tracer (Capability)
 """
 
 from .base_runner import BaseAgentRunner
 from .capabilities import Capability
 from .errors import structured_tool_error
 from .tool_error_recovery import ToolErrorRecovery
+from .tool_tracer import ToolTracer
 from .turn_budget import TurnBudget
 
 __all__ = [
@@ -18,5 +20,6 @@ __all__ = [
     "Capability",
     "structured_tool_error",
     "ToolErrorRecovery",
+    "ToolTracer",
     "TurnBudget",
 ]

--- a/sinan_agentic_core/core/tool_tracer.py
+++ b/sinan_agentic_core/core/tool_tracer.py
@@ -1,0 +1,145 @@
+"""Tool tracer — observation-only Capability for non-streaming runs.
+
+Prints a single line for every tool call (name, arguments, return value) and
+agent boundary during a run. Mirrors :class:`ToolErrorRecovery` and
+:class:`TurnBudget` in shape so it can be attached the same way::
+
+    tracer = ToolTracer(sink=print)
+    agent_def = AgentDefinition(..., capabilities=[tracer])
+
+Designed for non-streaming runs that have no ``on_event`` channel. The
+streaming path already emits ``tool_call`` / ``tool_output`` events, so
+consumers running ``streaming=True`` should keep using ``on_event``.
+
+The tracer never mutates state used by the agent — it only emits text to
+``sink``. That makes it safe to compose with other capabilities like
+:class:`ToolErrorRecovery`.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+from agents import RunContextWrapper, Tool
+
+from .capabilities import Capability
+
+
+class ToolTracer(Capability):
+    """Print every tool call and agent boundary during a run.
+
+    Each tool start/end and agent start/end is rendered as a single line
+    handed to ``sink`` (default :func:`print`). ``args`` and ``result`` are
+    truncated independently so noisy payloads do not flood the trace.
+
+    Attributes:
+        sink: One-arg callable that receives each line. Defaults to
+            :func:`print`. Pass a logger method (``logger.info``), a list's
+            ``append``, or any other ``Callable[[str], None]`` to redirect
+            output.
+        truncate_args: Maximum length of the arguments string before
+            truncation with ``...``. ``0`` disables truncation.
+        truncate_result: Maximum length of the result string before
+            truncation with ``...``. ``0`` disables truncation.
+        include_timestamps: When ``True``, every emitted line is prefixed
+            with a wall-clock ``HH:MM:SS.mmm`` timestamp.
+    """
+
+    def __init__(
+        self,
+        sink: Callable[[str], None] = print,
+        truncate_args: int = 200,
+        truncate_result: int = 500,
+        include_timestamps: bool = False,
+    ) -> None:
+        self.sink = sink
+        self.truncate_args = truncate_args
+        self.truncate_result = truncate_result
+        self.include_timestamps = include_timestamps
+
+    # ------------------------------------------------------------------ #
+    # Capability hooks
+    # ------------------------------------------------------------------ #
+
+    def on_agent_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        agent: Any,
+    ) -> None:
+        name = self._agent_name(agent)
+        self._emit(f"[agent start] {name}")
+
+    def on_agent_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        agent: Any,
+        output: Any,
+    ) -> None:
+        name = self._agent_name(agent)
+        self._emit(f"[agent end] {name}")
+
+    def on_tool_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        args: str,
+    ) -> None:
+        name = self._tool_name(tool)
+        rendered = self._truncate(args, self.truncate_args)
+        self._emit(f"[tool start] {name} args={rendered}")
+
+    def on_tool_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        tool: Tool,
+        result: str,
+    ) -> None:
+        name = self._tool_name(tool)
+        rendered = self._truncate(result, self.truncate_result)
+        self._emit(f"[tool end] {name} result={rendered}")
+
+    # ------------------------------------------------------------------ #
+    # Cloning
+    # ------------------------------------------------------------------ #
+
+    def clone(self) -> ToolTracer:
+        """Return a fresh tracer carrying the same configuration."""
+        return ToolTracer(
+            sink=self.sink,
+            truncate_args=self.truncate_args,
+            truncate_result=self.truncate_result,
+            include_timestamps=self.include_timestamps,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Private helpers
+    # ------------------------------------------------------------------ #
+
+    def _emit(self, line: str) -> None:
+        if self.include_timestamps:
+            line = f"{self._timestamp()} {line}"
+        self.sink(line)
+
+    @staticmethod
+    def _timestamp() -> str:
+        now = time.time()
+        local = time.localtime(now)
+        millis = int((now - int(now)) * 1000)
+        return f"{time.strftime('%H:%M:%S', local)}.{millis:03d}"
+
+    @staticmethod
+    def _truncate(value: str, limit: int) -> str:
+        text = value if isinstance(value, str) else str(value)
+        if limit <= 0 or len(text) <= limit:
+            return text
+        return text[:limit] + "..."
+
+    @staticmethod
+    def _tool_name(tool: Any) -> str:
+        return str(getattr(tool, "name", None) or tool)
+
+    @staticmethod
+    def _agent_name(agent: Any) -> str:
+        return str(getattr(agent, "name", None) or agent)

--- a/sinan_agentic_core/registry/capability_registry.py
+++ b/sinan_agentic_core/registry/capability_registry.py
@@ -114,3 +114,17 @@ def _build_error_recovery(config: dict[str, Any]) -> Capability:
     cfg = dict(config)
     cfg.setdefault("tool_registry", get_tool_registry())
     return ToolErrorRecovery(**cfg)
+
+
+@register_capability("tool_tracer")
+def _build_tool_tracer(config: dict[str, Any]) -> Capability:
+    """Build a :class:`ToolTracer` from YAML config.
+
+    YAML keys map straight to the constructor: ``truncate_args``,
+    ``truncate_result``, ``include_timestamps``. ``sink`` is not configurable
+    from YAML — it falls back to :func:`print`. Callers wiring a custom sink
+    should attach the tracer in code via ``capabilities=[ToolTracer(...)]``.
+    """
+    from ..core.tool_tracer import ToolTracer
+
+    return ToolTracer(**config)

--- a/tests/test_tool_tracer.py
+++ b/tests/test_tool_tracer.py
@@ -1,0 +1,364 @@
+"""Tests for :class:`ToolTracer` (core/tool_tracer.py).
+
+Covers:
+- Lifecycle hooks fire in order across multiple tool calls
+- ``truncate_args`` and ``truncate_result`` honor their limits
+- A custom ``sink`` captures every line (no leakage to ``print``)
+- Multi-agent runs (one agent invoking another) render readable boundaries
+- ``clone()`` produces an independent copy with the same configuration
+- Composition with ``ToolErrorRecovery`` and ``TurnBudget`` does not break
+  either capability's behavior
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from agents import RunContextWrapper
+
+from sinan_agentic_core.core.tool_error_recovery import ToolErrorRecovery
+from sinan_agentic_core.core.tool_tracer import ToolTracer
+from sinan_agentic_core.core.turn_budget import TurnBudget
+
+
+def _ctx() -> RunContextWrapper[Any]:
+    return RunContextWrapper(context=None)
+
+
+def _tool(name: str) -> Any:
+    t = Mock()
+    t.name = name
+    return t
+
+
+def _agent(name: str) -> Any:
+    a = Mock()
+    a.name = name
+    return a
+
+
+# ------------------------------------------------------------------ #
+# Hook firing order
+# ------------------------------------------------------------------ #
+
+
+class TestHookOrder:
+    def test_two_tool_calls_emit_in_order(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append)
+        ctx = _ctx()
+        agent = _agent("main")
+
+        tracer.on_agent_start(ctx, agent)
+        tracer.on_tool_start(ctx, _tool("alpha"), '{"x": 1}')
+        tracer.on_tool_end(ctx, _tool("alpha"), '{"ok": true}')
+        tracer.on_tool_start(ctx, _tool("beta"), '{"y": 2}')
+        tracer.on_tool_end(ctx, _tool("beta"), '{"ok": false}')
+        tracer.on_agent_end(ctx, agent, "done")
+
+        assert captured == [
+            "[agent start] main",
+            '[tool start] alpha args={"x": 1}',
+            '[tool end] alpha result={"ok": true}',
+            '[tool start] beta args={"y": 2}',
+            '[tool end] beta result={"ok": false}',
+            "[agent end] main",
+        ]
+
+    def test_anonymous_tool_falls_back_to_repr(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append)
+
+        bare = object()
+        tracer.on_tool_start(_ctx(), bare, "")
+        # No "name" attribute — line still renders without raising.
+        assert any("[tool start]" in line for line in captured)
+
+
+# ------------------------------------------------------------------ #
+# Truncation
+# ------------------------------------------------------------------ #
+
+
+class TestTruncation:
+    def test_truncate_args(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append, truncate_args=10)
+        long_args = "0123456789ABCDEFGHIJ"  # 20 chars
+
+        tracer.on_tool_start(_ctx(), _tool("t"), long_args)
+
+        assert captured == ["[tool start] t args=0123456789..."]
+
+    def test_truncate_result(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append, truncate_result=5)
+
+        tracer.on_tool_end(_ctx(), _tool("t"), "abcdefghij")
+
+        assert captured == ["[tool end] t result=abcde..."]
+
+    def test_zero_disables_truncation(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append, truncate_args=0, truncate_result=0)
+        long = "x" * 1000
+
+        tracer.on_tool_start(_ctx(), _tool("t"), long)
+        tracer.on_tool_end(_ctx(), _tool("t"), long)
+
+        assert captured == [f"[tool start] t args={long}", f"[tool end] t result={long}"]
+
+    def test_short_payload_unchanged(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append, truncate_args=200, truncate_result=500)
+
+        tracer.on_tool_start(_ctx(), _tool("t"), "tiny")
+        assert "..." not in captured[0]
+        assert captured[0].endswith("args=tiny")
+
+
+# ------------------------------------------------------------------ #
+# Custom sink isolation (no leak to print)
+# ------------------------------------------------------------------ #
+
+
+class TestSinkIsolation:
+    def test_custom_sink_captures_every_line(self, capsys: pytest.CaptureFixture[str]) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append)
+        ctx = _ctx()
+        agent = _agent("main")
+
+        tracer.on_agent_start(ctx, agent)
+        tracer.on_tool_start(ctx, _tool("t"), '{"k": "v"}')
+        tracer.on_tool_end(ctx, _tool("t"), '{"ok": true}')
+        tracer.on_agent_end(ctx, agent, "done")
+
+        # Every line landed in the custom sink.
+        assert len(captured) == 4
+        # Nothing printed to stdout/stderr — the default print sink was
+        # replaced and never consulted.
+        out = capsys.readouterr()
+        assert out.out == ""
+        assert out.err == ""
+
+    def test_default_sink_is_print(self, capsys: pytest.CaptureFixture[str]) -> None:
+        tracer = ToolTracer()
+        tracer.on_tool_start(_ctx(), _tool("t"), "{}")
+        out = capsys.readouterr()
+        assert "[tool start] t args={}" in out.out
+
+
+# ------------------------------------------------------------------ #
+# Timestamps
+# ------------------------------------------------------------------ #
+
+
+class TestTimestamps:
+    def test_include_timestamps_prepends_clock(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append, include_timestamps=True)
+        tracer.on_tool_start(_ctx(), _tool("t"), "{}")
+
+        assert len(captured) == 1
+        # HH:MM:SS.mmm prefix.
+        assert re.match(r"^\d{2}:\d{2}:\d{2}\.\d{3} \[tool start\] t", captured[0])
+
+    def test_timestamps_off_by_default(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append)
+        tracer.on_tool_start(_ctx(), _tool("t"), "{}")
+
+        assert captured[0].startswith("[tool start] t")
+
+
+# ------------------------------------------------------------------ #
+# Multi-agent boundaries (agent-as-tool style)
+# ------------------------------------------------------------------ #
+
+
+class TestMultiAgentBoundaries:
+    def test_nested_agent_run_emits_readable_lines(self) -> None:
+        """An agent invoking another via ``as_tool`` produces nested
+        agent_start/agent_end pairs around the inner tool calls."""
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append)
+        ctx = _ctx()
+        outer = _agent("planner")
+        inner = _agent("retriever")
+
+        tracer.on_agent_start(ctx, outer)
+        tracer.on_tool_start(ctx, _tool("retriever"), '{"q": "topic"}')
+        # Inner agent runs inside the as_tool call.
+        tracer.on_agent_start(ctx, inner)
+        tracer.on_tool_start(ctx, _tool("search"), '{"q": "topic"}')
+        tracer.on_tool_end(ctx, _tool("search"), '{"hits": 3}')
+        tracer.on_agent_end(ctx, inner, "summary")
+        tracer.on_tool_end(ctx, _tool("retriever"), "summary")
+        tracer.on_agent_end(ctx, outer, "answer")
+
+        assert captured == [
+            "[agent start] planner",
+            '[tool start] retriever args={"q": "topic"}',
+            "[agent start] retriever",
+            '[tool start] search args={"q": "topic"}',
+            '[tool end] search result={"hits": 3}',
+            "[agent end] retriever",
+            "[tool end] retriever result=summary",
+            "[agent end] planner",
+        ]
+
+
+# ------------------------------------------------------------------ #
+# clone() — independent copy with shared config
+# ------------------------------------------------------------------ #
+
+
+class TestClone:
+    def test_clone_carries_config(self) -> None:
+        sink: list[str] = []
+        original = ToolTracer(
+            sink=sink.append,
+            truncate_args=42,
+            truncate_result=84,
+            include_timestamps=True,
+        )
+
+        copy = original.clone()
+
+        assert copy is not original
+        assert copy.sink is original.sink
+        assert copy.truncate_args == 42
+        assert copy.truncate_result == 84
+        assert copy.include_timestamps is True
+
+    def test_clones_share_no_mutable_state(self) -> None:
+        # ToolTracer has no mutable per-run state, but the clone must still
+        # be a distinct object so future state additions don't leak.
+        original = ToolTracer()
+        copy = original.clone()
+        assert copy is not original
+        assert isinstance(copy, ToolTracer)
+
+    def test_clones_emit_independently(self) -> None:
+        a_sink: list[str] = []
+        b_sink: list[str] = []
+        a = ToolTracer(sink=a_sink.append)
+        b = a.clone()
+        b.sink = b_sink.append  # rebind sink on the clone
+
+        a.on_tool_start(_ctx(), _tool("alpha"), "{}")
+        b.on_tool_start(_ctx(), _tool("beta"), "{}")
+
+        assert a_sink == ["[tool start] alpha args={}"]
+        assert b_sink == ["[tool start] beta args={}"]
+
+
+# ------------------------------------------------------------------ #
+# Composition with ToolErrorRecovery / TurnBudget
+# ------------------------------------------------------------------ #
+
+
+class TestComposition:
+    def test_error_recovery_still_tracks_when_tracer_attached(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append)
+        recovery = ToolErrorRecovery()
+        ctx = _ctx()
+        tool = _tool("failing")
+
+        # Both capabilities receive every hook (the runtime fans them out).
+        tracer.on_tool_start(ctx, tool, '{"id": 1}')
+        recovery.on_tool_start(ctx, tool, '{"id": 1}')
+        tracer.on_tool_end(ctx, tool, json.dumps({"error": "boom"}))
+        recovery.on_tool_end(ctx, tool, json.dumps({"error": "boom"}))
+
+        # Recovery did its job.
+        assert recovery.has_errors
+        assert recovery.get_error_summary()["failing"]["error"] == "boom"
+        # Tracer also emitted lines for the same call.
+        assert any("[tool start] failing" in line for line in captured)
+        assert any("[tool end] failing" in line for line in captured)
+
+    def test_turn_budget_still_counts_when_tracer_attached(self) -> None:
+        captured: list[str] = []
+        tracer = ToolTracer(sink=captured.append)
+        budget = TurnBudget(default_turns=3)
+        ctx = _ctx()
+        agent = _agent("main")
+
+        tracer.on_agent_start(ctx, agent)
+        budget.on_llm_start(ctx, agent, None, [])
+        tracer.on_tool_start(ctx, _tool("t"), "{}")
+        tracer.on_tool_end(ctx, _tool("t"), "{}")
+        budget.on_llm_start(ctx, agent, None, [])
+        tracer.on_agent_end(ctx, agent, "done")
+
+        assert budget.turns_used == 2
+        assert budget.remaining == 1
+        # Tracer captured agent + tool boundaries.
+        assert captured[0] == "[agent start] main"
+        assert captured[-1] == "[agent end] main"
+
+
+# ------------------------------------------------------------------ #
+# Registry wiring
+# ------------------------------------------------------------------ #
+
+
+class TestRegistryFactory:
+    def test_tool_tracer_registered_with_defaults(self) -> None:
+        from sinan_agentic_core.registry.capability_registry import (
+            get_capability_registry,
+        )
+
+        reg = get_capability_registry()
+        cap = reg.build("tool_tracer")
+        assert isinstance(cap, ToolTracer)
+        assert cap.truncate_args == 200
+        assert cap.truncate_result == 500
+        assert cap.include_timestamps is False
+
+    def test_tool_tracer_accepts_yaml_config(self) -> None:
+        from sinan_agentic_core.registry.capability_registry import (
+            get_capability_registry,
+        )
+
+        reg = get_capability_registry()
+        cap = reg.build(
+            "tool_tracer",
+            {
+                "truncate_args": 50,
+                "truncate_result": 100,
+                "include_timestamps": True,
+            },
+        )
+        assert isinstance(cap, ToolTracer)
+        assert cap.truncate_args == 50
+        assert cap.truncate_result == 100
+        assert cap.include_timestamps is True
+
+
+# ------------------------------------------------------------------ #
+# Top-level re-exports
+# ------------------------------------------------------------------ #
+
+
+class TestPublicAPI:
+    def test_top_level_export(self) -> None:
+        import sinan_agentic_core as pkg
+
+        assert hasattr(pkg, "ToolTracer")
+        assert pkg.ToolTracer is ToolTracer
+        assert "ToolTracer" in pkg.__all__
+
+    def test_core_export(self) -> None:
+        import sinan_agentic_core.core as core
+
+        assert hasattr(core, "ToolTracer")
+        assert core.ToolTracer is ToolTracer
+        assert "ToolTracer" in core.__all__


### PR DESCRIPTION
## Summary
- New `ToolTracer(Capability)` at `sinan_agentic_core/core/tool_tracer.py` — observation-only tracer that emits one line per agent boundary and per tool start/end to a configurable `sink` (default `print`), with independent `truncate_args` / `truncate_result` limits and optional wall-clock timestamps.
- Registered as the `tool_tracer` factory in `CapabilityRegistry`, re-exported from `sinan_agentic_core.core` and the package root, so YAML agents can opt in with `capabilities: [tool_tracer]` and Python users with `capabilities=[ToolTracer()]`.
- Docs: README capabilities tagline, custom-capabilities reference, project structure tree, and a new "Tool Tracer (Non-Streaming Observability)" section; `documentation/project/capabilities.md` gains a third row in the built-in capabilities table.

## Test plan
- [x] `pytest tests/test_tool_tracer.py` — covers hook firing order across two tool calls, args/result truncation, custom sink (no leakage to `print`), multi-agent runs via `as_tool` showing readable agent-boundary lines, and `clone()` independence.
- [x] `pytest` full suite — `TurnBudget` and `ToolErrorRecovery` suites still pass with a `ToolTracer` attached to the same agent.
- [ ] Manual: run an example with `ToolTracer(sink=print)` against a non-streaming `BaseAgentRunner.execute(...)` and confirm the trace lines.