### PR TITLE
feat(core): add fallback hooks to Capability protocol

### DIFF
--- a/documentation/project/capabilities.md
+++ b/documentation/project/capabilities.md
@@ -35,6 +35,8 @@ The full surface lives in `sinan_agentic_core/core/capabilities/base.py`:
 | `on_tool_end(ctx, tool, result)` | Tool finished |
 | `on_llm_start(ctx, agent, system_prompt, input_items)` | Model call begins |
 | `on_llm_end(ctx, agent, response)` | Model call returns |
+| `on_fallback_start(ctx, prompt, collected_items)` | Recovery branch of `_execute_with_fallback` is about to send its condensed chat-completions call (after the agent loop raised `Max turns` / `context_length_exceeded`) |
+| `on_fallback_end(ctx, response, usage)` | Recovery LLM call returned, before output-type parsing |
 | `tools()` | Extra tools the capability exposes to the agent |
 | `reset()` | Called at the start of every `execute()` - clear mutable state |
 | `clone()` | Per-run copy; default is `copy.deepcopy(self)` |
@@ -77,6 +79,27 @@ final_output (caps still hold post-run state for inspection)
 The cloning rule is the key isolation guarantee: declarative capabilities on
 `AgentDefinition` are templates, the runner clones them per call, so two
 concurrent runs never share `turns_used` or error history.
+
+### Fallback recovery hooks
+
+`fallback_on_overflow=True` enables a recovery branch in `_execute_with_fallback`
+that catches `Max turns` / `context_length_exceeded` from the agent loop and
+makes a single condensed chat-completions call to rescue the run. That call
+bypasses `Runner.run`, so the SDK lifecycle hooks (`on_agent_start`,
+`on_tool_start`, etc.) do not fire on it. Two dedicated hooks cover the gap:
+
+- `on_fallback_start(ctx, prompt, collected_items)` — fires after the recovery
+  prompt is built and before the chat-completions request is sent. Use it to
+  audit-log the fallback prompt, count fallbacks, or capture the gathered tool
+  outputs.
+- `on_fallback_end(ctx, response, usage)` — fires after the recovery call
+  returns and before any output-type parsing. Use it to inspect or validate
+  rescued outputs (typically the most interesting runs — they nearly failed).
+
+Tool-event hooks are intentionally **not** fired on the recovery branch: no
+tools are invoked there, so dispatching them would be misleading. The hooks
+also do not fire on the normal-success path of `_execute_with_fallback` — only
+when the recovery branch actually runs.
 
 ## Writing a custom capability
 

--- a/sinan_agentic_core/core/base_runner.py
+++ b/sinan_agentic_core/core/base_runner.py
@@ -396,6 +396,9 @@ class BaseAgentRunner:
             builder = fallback_prompt_builder or self._default_fallback_prompt_builder
             prompt = builder(instructions, collecting.raw_items, agent_def)
 
+            for cap in capabilities:
+                cap.on_fallback_start(ctx_wrapper, prompt, collecting.raw_items)
+
             from agents.models._openai_shared import get_default_openai_key
             from openai import AsyncOpenAI
 
@@ -443,8 +446,9 @@ class BaseAgentRunner:
             content = response.choices[0].message.content
 
             # Capture fallback usage from the direct LLM call
+            fallback_usage: dict[str, Any] | None = None
             if response.usage:
-                self.last_usage = {
+                fallback_usage = {
                     "requests": 1,
                     "input_tokens": response.usage.prompt_tokens or 0,
                     "output_tokens": response.usage.completion_tokens or 0,
@@ -452,6 +456,10 @@ class BaseAgentRunner:
                     "input_tokens_details": {"cached_tokens": 0},
                     "output_tokens_details": {"reasoning_tokens": 0},
                 }
+                self.last_usage = fallback_usage
+
+            for cap in capabilities:
+                cap.on_fallback_end(ctx_wrapper, content, fallback_usage)
 
             if not use_json:
                 return content

--- a/sinan_agentic_core/core/capabilities/base.py
+++ b/sinan_agentic_core/core/capabilities/base.py
@@ -115,6 +115,43 @@ class Capability:
         """Called immediately after the model returns a response."""
         return None
 
+    def on_fallback_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        prompt: str,
+        collected_items: list[Any],
+    ) -> None:
+        """Called immediately before the summarize-and-extract recovery LLM call.
+
+        Fires only on the recovery branch of ``_execute_with_fallback`` — when
+        the agent loop has raised a recoverable overflow (``Max turns`` /
+        ``context_length_exceeded``) and the runner is about to send a single
+        condensed chat-completions request that bypasses ``Runner.run``.
+
+        ``prompt`` is the fully-rendered recovery prompt; ``collected_items``
+        is the list of raw session items gathered during the failed agent
+        loop (the same list passed to the fallback-prompt builder). Tool-event
+        hooks (``on_tool_start`` / ``on_tool_end``) are intentionally **not**
+        fired on this path — no tools are invoked.
+        """
+        return None
+
+    def on_fallback_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        response: str | None,
+        usage: dict[str, Any] | None,
+    ) -> None:
+        """Called immediately after the recovery LLM call returns.
+
+        Fires only on the recovery branch of ``_execute_with_fallback``,
+        before any output-type parsing. ``response`` is the raw assistant
+        message content from the chat-completions call (``None`` if the
+        provider returned no content); ``usage`` is the token-usage dict
+        captured from the response (``None`` if the provider omitted it).
+        """
+        return None
+
     def reset(self) -> None:
         """Reset mutable state. Called at the start of each ``execute()`` call."""
         return None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -707,6 +707,113 @@ class TestExecuteWithFallback:
         assert isinstance(captured_hooks["hooks"], _CompositeHooks)
         assert recorded_tool_starts == ["test_tool"]
 
+    async def test_recovery_branch_fires_fallback_hooks(self, runner):
+        """Recovery branch invokes on_fallback_start / on_fallback_end on capabilities.
+
+        Tool-event hooks must NOT fire on the recovery branch (no tools run).
+        """
+        from sinan_agentic_core.core.capabilities import Capability
+
+        class _RecorderCapability(Capability):
+            def __init__(self):
+                self.starts: list[tuple[str, list]] = []
+                self.ends: list[tuple[str | None, dict | None]] = []
+                self.tool_starts: list[str] = []
+                self.tool_ends: list[str] = []
+
+            def on_fallback_start(self, ctx, prompt, collected_items):
+                self.starts.append((prompt, list(collected_items)))
+
+            def on_fallback_end(self, ctx, response, usage):
+                self.ends.append((response, usage))
+
+            def on_tool_start(self, ctx, tool, args):
+                self.tool_starts.append(getattr(tool, "name", "?"))
+
+            def on_tool_end(self, ctx, tool, result):
+                self.tool_ends.append(str(result))
+
+        recorder = _RecorderCapability()
+        ctx = AgentContext(database_connector=Mock())
+        session = AgentSession(session_id="test")
+
+        mock_completion = Mock()
+        mock_completion.choices = [Mock()]
+        mock_completion.choices[0].message.content = "Rescued output"
+        mock_completion.usage = Mock(prompt_tokens=100, completion_tokens=20, total_tokens=120)
+
+        with (
+            patch.object(runner, "create_agent", new_callable=AsyncMock, return_value=Mock()),
+            patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
+            patch("openai.AsyncOpenAI") as mock_openai,
+        ):
+            mock_runner_cls.run = AsyncMock(side_effect=RuntimeError("Max turns exceeded"))
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+            mock_openai.return_value = mock_client
+
+            result = await runner._execute_with_fallback(
+                "basic_agent",
+                ctx,
+                session,
+                10,
+                "hello",
+                None,
+                capabilities=[recorder],
+            )
+
+        assert result == "Rescued output"
+        assert len(recorder.starts) == 1
+        prompt, collected_items = recorder.starts[0]
+        assert "You are a basic agent" in prompt
+        assert isinstance(collected_items, list)
+        assert len(recorder.ends) == 1
+        response, usage = recorder.ends[0]
+        assert response == "Rescued output"
+        assert usage is not None
+        assert usage["input_tokens"] == 100
+        assert usage["output_tokens"] == 20
+        # Tool-event hooks must NOT fire on the recovery branch.
+        assert recorder.tool_starts == []
+        assert recorder.tool_ends == []
+
+    async def test_normal_success_path_does_not_fire_fallback_hooks(self, runner, mock_run_result):
+        """When Runner.run succeeds, fallback hooks must not fire."""
+        from sinan_agentic_core.core.capabilities import Capability
+
+        class _Recorder(Capability):
+            def __init__(self):
+                self.start_calls = 0
+                self.end_calls = 0
+
+            def on_fallback_start(self, ctx, prompt, collected_items):
+                self.start_calls += 1
+
+            def on_fallback_end(self, ctx, response, usage):
+                self.end_calls += 1
+
+        recorder = _Recorder()
+        ctx = AgentContext(database_connector=Mock())
+        session = AgentSession(session_id="test")
+
+        with (
+            patch.object(runner, "create_agent", new_callable=AsyncMock, return_value=Mock()),
+            patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
+        ):
+            mock_runner_cls.run = AsyncMock(return_value=mock_run_result)
+            await runner._execute_with_fallback(
+                "basic_agent",
+                ctx,
+                session,
+                10,
+                "hello",
+                None,
+                capabilities=[recorder],
+            )
+
+        assert recorder.start_calls == 0
+        assert recorder.end_calls == 0
+
     async def test_normal_path_omits_hooks_when_no_capabilities(self, runner, mock_run_result):
         """No hooks kwarg is passed when there are no capabilities."""
         ctx = AgentContext(database_connector=Mock())


### PR DESCRIPTION
Closes #30

## Summary

- Adds `on_fallback_start` and `on_fallback_end` to the `Capability` protocol so capabilities can observe the summarize-and-extract recovery branch in `BaseAgentRunner._execute_with_fallback`.
- Both hooks default to no-ops; existing capabilities keep working unchanged.
- Hooks fire only when the recovery branch actually runs — tool-event hooks remain unfired on that path (no tools are invoked there).
- Documents the new surface in `documentation/project/capabilities.md`.

## Test plan

- [ ] `pytest tests/test_core.py -q` — covers the new stub capability that forces a fallback via `MaxTurnsExceeded` and asserts both hooks fire with the expected prompt/response payloads, and that `on_tool_start` / `on_tool_end` do not fire on the recovery branch.
- [ ] `pytest` — full suite still green.