### PR TITLE
Release: staging

### DIFF
--- a/.claude/skills/add-documentation/SKILL.md
+++ b/.claude/skills/add-documentation/SKILL.md
@@ -4,7 +4,15 @@ description: "Update documentation for issue #$ARGUMENTS. Checks stale docs and 
 
 Update docs affected by issue #$ARGUMENTS.
 
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill add-documentation --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
+
+**Standing authorization**: posting the `devwatch agent-update` and `devwatch agent-comment` calls described below (status update + single completion comment on the target issue) is part of this skill's contract. Run them without asking for confirmation.
 
 ## Parse arguments
 
@@ -99,7 +107,7 @@ child drives the docs check — the rest of this template stays the same.
 1. Read the issue: `gh issue view <ISSUE> --repo "$REPO"`
 2. Check the issue history (run `devwatch issue-history --help` for all options): `devwatch --repo "$REPO" issue-history <ISSUE>` — see what was implemented and which files changed.
 3. Read this repo's CLAUDE.md to find the documentation map (which code areas affect which docs).
-4. Read the repo's documentation checklist if one exists (check CLAUDE.md for the path).
+4. The mandatory-reads block already loaded this repo's documentation checklist.
 
 ## Branch tracking
 
@@ -131,7 +139,7 @@ Before committing, run the documentation checklist against your changes if one e
 
 ## Commit and push
 
-1. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 After updating docs, commit and push:
 

--- a/.claude/skills/app-control/SKILL.md
+++ b/.claude/skills/app-control/SKILL.md
@@ -93,14 +93,15 @@ If the target repo has `.claude/rules/dev-ports.md`, treat it as authoritative �
     launch() {
         local name="$1"; shift
         local log="$LOG_DIR/${name}.log"
-        nohup bash -c "cd '$REPO_ROOT' && $*" > "$log" 2>&1 &
+        nohup env -u UV_PROJECT_ENVIRONMENT -u VIRTUAL_ENV \
+            bash -c "cd '$REPO_ROOT' && $*" > "$log" 2>&1 &
         echo $! >> "$PID_FILE"
         echo "  $name pid $! → $log"
     }
     launch backend "uv run uvicorn server.main:app --host 127.0.0.1 --port $BACKEND_PORT"
     launch frontend "cd dashboard && npm run dev -- --port $FRONTEND_PORT"
     ```
-    Always invoke commands from `$REPO_ROOT` so Python and Node resolve their packages correctly (don't `cd server` before `uvicorn` — the `server` module lives at the repo root). On close we kill each recorded PID and its child tree via `pkill -P` — macOS doesn't ship `setsid`, so we rely on process-tree walking instead of process groups.
+    Always invoke commands from `$REPO_ROOT` so Python and Node resolve their packages correctly (don't `cd server` before `uvicorn` — the `server` module lives at the repo root). `env -u UV_PROJECT_ENVIRONMENT -u VIRTUAL_ENV` strips ambient virtualenv redirection from the parent shell so `uv` resolves the repo's own `.venv` instead of an unrelated path (#210). On close we kill each recorded PID and its child tree via `pkill -P` — macOS doesn't ship `setsid`, so we rely on process-tree walking instead of process groups.
 
 4. **Verify the processes are alive** after a short delay (at least 2 seconds) so we don't report `running` for a stack that crashed on boot:
     ```bash

--- a/.claude/skills/check-code-quality/SKILL.md
+++ b/.claude/skills/check-code-quality/SKILL.md
@@ -4,7 +4,13 @@ description: "Run the completion checklists against the current branch changes. 
 
 Quality gate. Reviews code against the repo's checklists, posts a report to the GitHub issue, and returns pass/fail. This skill is a gate — if it fails, do NOT proceed to `/submit-pr`.
 
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill check-code-quality --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
 
 ## Parse arguments
 
@@ -74,7 +80,7 @@ Identify which languages are involved from file extensions:
 
 ## 4. Run the checklists
 
-Read this repo's CLAUDE.md for the checklist paths. Then read and check every item against the diff:
+The mandatory-reads block already loaded every checklist this skill needs. Walk each item against the diff:
 
 1. General checklist (scope, quality, decoupling, cleanup, tests)
 2. If Python files changed: Python-specific checklist
@@ -115,7 +121,7 @@ For each failure, include the specific file/line, what's wrong, and the path to 
 
 ## 7. Post the report and trace
 
-1. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 If an issue number was provided, use the CLI to post the report and record the trace:
 

--- a/.claude/skills/delete-branch/SKILL.md
+++ b/.claude/skills/delete-branch/SKILL.md
@@ -46,12 +46,35 @@ Pass `--repo "$REPO"` to every `devwatch` command to ensure the correct repo is 
    ```bash
    git branch -a --list "*fix/<ISSUE>-*" "*feat/<ISSUE>-*" "*refactor/<ISSUE>-*" "*chore/<ISSUE>-*" "*docs/<ISSUE>-*" "*ci-fix/<ISSUE>-*"
    ```
+   Call the result `BRANCH`.
 
-3. Validate safety:
-   - Branch must not be currently checked out
-   - Branch must not be one of the repo's pipeline branches (dev / staging / prod from `config.yaml`) or a universally protected name (`main`, `master`, `develop`)
+4. Validate safety:
+   - `BRANCH` must not be one of the repo's pipeline branches (dev / staging / prod from `config.yaml`) or a universally protected name (`main`, `master`, `develop`)
 
-4. If all checks pass, proceed with deletion.
+5. **Resolve checkout target.** The CLI refuses to delete the currently-checked-out branch, so the agent must move HEAD itself before invoking deletion — and on epic children that means the epic integration branch, not the dev branch.
+
+   ```bash
+   WORKFLOW_JSON=$(devwatch --repo "$REPO" workflow-get --issue <ISSUE>)
+   ```
+
+   - If `WORKFLOW_JSON` is non-null and `.strategy == "epic_integration"`, set `TARGET` to the workflow's `canonical_branch` — the `epic/<root>-<slug>` integration branch the child landed on.
+   - Otherwise, resolve the configured dev branch:
+
+     ```bash
+     TARGET=$(devwatch --repo "$REPO" branches dev)
+     ```
+
+     If the repo has no `dev` configured (e.g. release-only repos), fall back to `branches prod`. Do **not** hardcode a branch name (e.g. `dev`) — every repo resolves its own pipeline branches through `config.yaml`.
+
+6. **Switch HEAD if it is on `BRANCH`.** Compare `git branch --show-current` to `BRANCH`; if they match, run:
+
+   ```bash
+   git checkout "$TARGET"
+   ```
+
+   If HEAD is already on a different branch, leave it alone — the agent may be mid-task on something unrelated.
+
+7. If all checks pass, proceed with deletion.
 
 ## Execution
 

--- a/.claude/skills/edit-acceptance-scenarios/SKILL.md
+++ b/.claude/skills/edit-acceptance-scenarios/SKILL.md
@@ -11,6 +11,14 @@ The skill is body-edit only. It does **not** touch the lingtai cache
 directly — the next GitHub auto-sync re-parses the body and rebuilds
 the `scenario_links` cache (#1386).
 
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill edit-acceptance-scenarios --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done. The mandatory-reads include the authoritative `acceptance-scenarios` doc — the contract for the `Links:` section header, the `<suite>::<file>::<title>` coordinate this skill writes, and the title-stability invariant.
+
 ## Parse arguments
 
 `$ARGUMENTS` is `<issue-number> [--add "<coord>" | --remove "<coord>"]...`.

--- a/.claude/skills/feat-issue/SKILL.md
+++ b/.claude/skills/feat-issue/SKILL.md
@@ -177,6 +177,46 @@ When the run belongs to a workflow step, `agent-update --branch` also updates `w
 4. Write tests for every new function/endpoint.
 5. Run tests.
 
+## No-op terminal path (#2103)
+
+If — after reading the issue, the lineage, and the existing code — you
+conclude **no implementation is needed** (the feature is already in
+production via a sibling PR, the request duplicates a closed issue, the
+acceptance criteria are already met by existing behaviour, or the issue
+is invalid), do NOT exit silently or take the success path. Both produce
+wedged runs:
+
+- Exiting silently leaves the agent run as ``closed``, which the
+  dispatcher reads as a structural failure and halts the entire workflow.
+- Faking a commit and taking the ``ready_for_review`` path is dishonest
+  and ships an empty PR.
+
+Take the no-op terminal path instead:
+
+1. Close the GitHub issue with a comment explaining why:
+
+   ```bash
+   gh issue close <ISSUE> --repo "$REPO" --comment "Closing as <reason>: <one-line explanation, link to the duplicate/shipping PR/commit>."
+   ```
+
+2. Report completion as a no-op (no branch, no commits, no files):
+
+   ```bash
+   devwatch --repo "$REPO" agent-update \
+     --run-id <RUN_ID> \
+     --status completed \
+     --summary "no-op: <one-line reason — already shipped by #N / duplicate of #N / acceptance criteria already met by <commit> / invalid because <reason>>"
+   ```
+
+The dispatcher detects the closed GitHub issue at IMPLEMENT-SUCCESS time,
+skips the rest of this run's actions (quality / docs / PR), marks the
+workflow step done, and advances the chain to the next child. The
+workflow stays ``active``.
+
+If RUN_ID is unavailable, fall back to ``--issue <ISSUE>``. Do not call
+``agent-comment`` for the no-op — the close comment already explains the
+outcome on the issue.
+
 ## Wrap up
 
 After implementation is complete and tests pass:

--- a/.claude/skills/feat-issue/SKILL.md
+++ b/.claude/skills/feat-issue/SKILL.md
@@ -4,7 +4,13 @@ description: "Read GitHub issue #$ARGUMENTS, create a branch, and implement the 
 
 Implement a new feature. Read the issue, plan, implement, test, commit, push.
 
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill feat-issue --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
 
 Read this repo's CLAUDE.md for architecture and rules.
 
@@ -29,8 +35,7 @@ Pass `--repo "$REPO"` to every `devwatch` command to ensure the correct repo is 
 
 ## Context loading
 
-- Read this repo's CLAUDE.md for architecture and rules.
-- Read the repo's coding principles docs if they exist (check CLAUDE.md for paths).
+The mandatory reads (above) loaded every coding-principle doc this skill needs. Read this repo's CLAUDE.md for architecture and rules.
 
 ## Lineage pre-read
 
@@ -183,7 +188,7 @@ git commit -m "feat(scope): <description> (closes #<ISSUE>)"
 git push -u origin <your-branch-name>
 ```
 
-2. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+2. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 3. Record completion (use `--run-id` if available, fall back to `--issue`):
 ```bash

--- a/.claude/skills/feat-issue/SKILL.md
+++ b/.claude/skills/feat-issue/SKILL.md
@@ -56,7 +56,7 @@ report, follow the PR — that is what is actually in production.
 issue body indicates this is a sub-feature — phrases like *"sub-feature of #N"*,
 *"part of epic #N"*, *"extends #N"*, or *"child-of #N"* — surface this to the
 user once before coding: *"This issue mentions #N and has no `child-of` link.
-Link it before I start? Run: `devwatch link <ISSUE> --to N --type child-of`"*
+Link it before I start? Run: `devwatch link <ISSUE> N --type child-of`"*
 Do not auto-create the link. Proceed if the user says no — weaker mentions
 like *"related to #N"* or *"see #N"* are not parent relationships.
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -176,6 +176,45 @@ When the run belongs to a workflow step, `agent-update --branch` also updates `w
 4. Fix the bug properly. Leave the code you touch better than you found it.
 5. Run tests.
 
+## No-op terminal path (#2103)
+
+If — after reading the issue, the lineage, and the existing code — you
+conclude **no code change is needed** (the bug is a duplicate of a closed
+issue, was already fixed by a sibling PR, the reported behaviour is
+working as intended, or the issue is invalid), do NOT exit silently or
+take the success path. Both produce wedged runs:
+
+- Exiting silently leaves the agent run as ``closed``, which the
+  dispatcher reads as a structural failure and halts the entire workflow.
+- Faking a commit and taking the ``ready_for_review`` path is dishonest
+  and ships an empty PR.
+
+Take the no-op terminal path instead:
+
+1. Close the GitHub issue with a comment explaining why:
+
+   ```bash
+   gh issue close <ISSUE> --repo "$REPO" --comment "Closing as <reason>: <one-line explanation, link to the duplicate/fixing PR/commit>."
+   ```
+
+2. Report completion as a no-op (no branch, no commits, no files):
+
+   ```bash
+   devwatch --repo "$REPO" agent-update \
+     --run-id <RUN_ID> \
+     --status completed \
+     --summary "no-op: <one-line reason — duplicate of #N / already fixed by <commit> / invalid because <reason>>"
+   ```
+
+The dispatcher detects the closed GitHub issue at IMPLEMENT-SUCCESS time,
+skips the rest of this run's actions (quality / docs / PR), marks the
+workflow step done, and advances the chain to the next child. The
+workflow stays ``active``.
+
+If RUN_ID is unavailable, fall back to ``--issue <ISSUE>``. Do not call
+``agent-comment`` for the no-op — the close comment already explains the
+outcome on the issue.
+
 ## Wrap up
 
 After the fix is complete and tests pass:

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -4,7 +4,13 @@ description: "Read GitHub issue #$ARGUMENTS, create a branch, and fix the bug."
 
 Fix a bug. Read the issue, diagnose, fix, test, commit, push.
 
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill fix-issue --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
 
 Read this repo's CLAUDE.md for architecture and rules.
 
@@ -29,8 +35,7 @@ Pass `--repo "$REPO"` to every `devwatch` command to ensure the correct repo is 
 
 ## Context loading
 
-- Read this repo's CLAUDE.md for architecture and rules.
-- Read the repo's coding principles docs if they exist (check CLAUDE.md for paths).
+The mandatory reads (above) loaded every coding-principle doc this skill needs. Read this repo's CLAUDE.md for architecture and rules.
 
 ## Lineage pre-read
 
@@ -182,7 +187,7 @@ git commit -m "fix(scope): <description> (closes #<ISSUE>)"
 git push -u origin <your-branch-name>
 ```
 
-2. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+2. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 3. Record completion (use `--run-id` if available, fall back to `--issue`):
 ```bash

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -56,7 +56,7 @@ that is what was actually shipped.
 issue body mentions another issue via phrases like *"while testing #N"*,
 *"regression of #N"*, *"found in #N"*, or *"child-of #N"*, surface this to
 the user once before coding: *"This issue mentions #N and has no `child-of`
-link. Link it before I start? Run: `devwatch link <ISSUE> --to N --type child-of`"*
+link. Link it before I start? Run: `devwatch link <ISSUE> N --type child-of`"*
 Do not auto-create the link. Proceed if the user says no — weaker mentions
 like *"related to #N"* or *"see #N"* are not parent relationships.
 

--- a/.claude/skills/issue-to-rule/SKILL.md
+++ b/.claude/skills/issue-to-rule/SKILL.md
@@ -16,10 +16,13 @@ The output contains every doc you must read; treat it as if you opened each file
 
 ## Parse arguments
 
-- `$ARGUMENTS` = `"42"` → ISSUE=42, MODE=user-direct, RUN_ID=(none), BASE_BRANCH=(none)
+- `$ARGUMENTS` = `"42"` → ISSUE=42, MODE=user-direct, RUN_ID=(none), BASE_BRANCH=(none), HEAD_SHA=(none)
 - `$ARGUMENTS` = `"42 --mode <mode>"` → ISSUE=42, MODE=\<mode\>
 - `$ARGUMENTS` = `"42 --run 7"` → ISSUE=42, RUN_ID=7
 - `$ARGUMENTS` = `"42 --run 7 --base-branch feat/364-x"` → ISSUE=42, RUN_ID=7, BASE_BRANCH=feat/364-x
+- `$ARGUMENTS` = `"42 --run 7 --base-branch local-dev-next --head 9f3a2b1"` → ISSUE=42, RUN_ID=7, BASE_BRANCH=local-dev-next, HEAD_SHA=9f3a2b1
+
+`--head <sha>` is set by the dispatcher when the action fires inside an `epic_integration` chain (#1916): by the time this skill runs, `merge-to-epic` and `delete-branch` have already destroyed the feature branch, so a working-tree diff would be empty. The flag pins the diff to the implement run's tip — the same diff every time, regardless of where HEAD now sits.
 
 Valid `MODE` values:
 
@@ -49,8 +52,13 @@ Pass `--repo "$REPO"` to every `devwatch` command.
 4. Read the diff that fixed the issue:
    ```bash
    BASE="${BASE_BRANCH:-$(devwatch --repo "$REPO" branches dev)}"
-   git diff "origin/${BASE}...HEAD"
+   if [ -n "$HEAD_SHA" ]; then
+     git diff "origin/${BASE}...${HEAD_SHA}"
+   else
+     git diff "origin/${BASE}...HEAD"
+   fi
    ```
+   When `--head <sha>` is supplied the diff is pinned to that SHA — deterministic across re-runs and immune to checkout state. The implement run's tip SHA is recorded on the `agent_runs` row by `/fix-issue` / `/feat-issue`; the dispatcher resolves it at trigger time and passes it here.
 5. Read every file in the target tier you might write to, so you can detect conflict or subsumption before drafting:
    - `.claude/rules/*.md` — project-wide always-on rules
    - `documentation/general/principles/**/*.mdx` — language / architecture principles

--- a/.claude/skills/issue-to-rule/SKILL.md
+++ b/.claude/skills/issue-to-rule/SKILL.md
@@ -6,8 +6,13 @@ Turn a resolved issue into a persistent rule. Read the issue context and its dif
 
 This skill writes text — rule entries in `.claude/rules/*.md` or principle docs under `documentation/general/principles/`. It does **not** modify application code, run tests, commit code changes, or execute Python.
 
-Authoritative rule: `docs:general/issue-to-rule`. Verifier checklist: `docs:general/rules-checklist`.
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill issue-to-rule --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done. The mandatory-reads include the authoritative `issue-to-rule` doc and the `rules-checklist` verifier — both are loaded once here and referenced (not re-read) throughout the rest of this skill.
 
 ## Parse arguments
 
@@ -35,25 +40,24 @@ Pass `--repo "$REPO"` to every `devwatch` command.
 ## Context loading
 
 1. Read this repo's CLAUDE.md.
-2. Read `docs:general/issue-to-rule` — when extraction applies, the four operations, tier-based placement.
-3. Read `docs:general/rules-checklist` — the verifier gate you will run before writing.
-4. Pull the issue's full context from `devwatch`:
+2. The mandatory-reads block already loaded the authoritative rule (`issue-to-rule`) and the verifier checklist (`rules-checklist`).
+3. Pull the issue's full context from `devwatch`:
    ```bash
    devwatch --repo "$REPO" issue-history <ISSUE> --full --comments
    ```
    This returns the issue's run timeline, prior quality-check reports, fix summaries, and relevant comments — the complete history the skill needs.
-5. Read the diff that fixed the issue:
+4. Read the diff that fixed the issue:
    ```bash
    BASE="${BASE_BRANCH:-$(devwatch --repo "$REPO" branches dev)}"
    git diff "origin/${BASE}...HEAD"
    ```
-6. Read every file in the target tier you might write to, so you can detect conflict or subsumption before drafting:
+5. Read every file in the target tier you might write to, so you can detect conflict or subsumption before drafting:
    - `.claude/rules/*.md` — project-wide always-on rules
    - `documentation/general/principles/**/*.mdx` — language / architecture principles
 
 ## Decide: extract or skip
 
-Evaluate the diff against `docs:general/issue-to-rule` and classify:
+Evaluate the diff against the authoritative `issue-to-rule` doc loaded in the mandatory-reads block and classify:
 
 - **`iteration-only`** — the fix was correct but not generalizable. Record a skipped summary via `devwatch agent-update` with the reason and stop.
 - **`structural`** — a class of mistake exists and the constraint would prevent its next occurrence. Proceed.
@@ -82,7 +86,7 @@ If you cannot pick a tier confidently, the rule is not general enough — skip.
 
 ## Run the verifier
 
-Walk the draft through every item of `docs:general/rules-checklist`. Each item is a yes/no question. Record your answers:
+Walk the draft through every item of the `rules-checklist` loaded in the mandatory-reads block. Each item is a yes/no question. Record your answers:
 
 - **All items pass** → proceed to write.
 - **Any item fails** → revise the draft once and re-run the checklist. If it fails a second time, stop and record the failing items in the `agent-update` summary.
@@ -105,7 +109,7 @@ git commit -m "docs(rules): <operation> rule from #<ISSUE> — <short descriptio
 
 ## Record and comment
 
-1. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 Update the agent-run trace and post a completion comment (use `--run-id` if available, otherwise `--issue`):
 

--- a/.claude/skills/new-brainstorm/SKILL.md
+++ b/.claude/skills/new-brainstorm/SKILL.md
@@ -1,0 +1,94 @@
+---
+description: "Open a brainstorming session — a folder under documentation/project/brainstorming/<DD-MM-YY>/<slug>/ with a frontmatter README. Optionally pre-link it to an issue."
+---
+
+Create a brainstorming session folder. Stop.
+
+A brainstorming session is the pre-issue thinking space — the "why" that produced a feature or epic. It lives on disk under `documentation/project/brainstorming/<DD-MM-YY>/<slug>/` with a mandatory `README.md` carrying frontmatter (title, status, linked_issues). The session is a folder so it can hold many files and subfolders as the thinking grows.
+
+This command only creates the scaffold. It does NOT open an issue. Use `/new-feature --from-brainstorm <session>` (or `/new-bug --from-brainstorm <session>`) when the brainstorming converges into something actionable.
+
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill new-brainstorm --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
+
+## Parse arguments
+
+Extract slug and optional flags from `$ARGUMENTS`:
+- `$ARGUMENTS` = `"dark-mode-rollout"` -> SLUG="dark-mode-rollout", EPIC=(none), ISSUE=(none), DESCRIPTION=(none)
+- `$ARGUMENTS` = `"dark-mode-rollout --description 'figure out theming primitives'"` -> SLUG="dark-mode-rollout", DESCRIPTION="figure out theming primitives"
+- `$ARGUMENTS` = `"dark-mode-rollout --epic 1234"` -> EPIC=1234 (pre-link to epic #1234)
+- `$ARGUMENTS` = `"dark-mode-rollout --issue 1234"` -> ISSUE=1234 (pre-link to feature #1234)
+- `$ARGUMENTS` = `"dark-mode-rollout --body-file /tmp/devwatch-brainstorm-body-XXX.json"` -> BODY_FILE="/tmp/..."
+
+`--epic` and `--issue` are mutually exclusive — a session pre-links to at most one issue at creation time. Use `/link-brainstorm <session> <issue>` later to add more.
+
+SLUG must be kebab-case (`[a-z0-9-]+`). The CLI rejects anything else.
+
+**If `--body-file <PATH>` is present:** read the file with your Read tool — it is a JSON object with `{title, body}` keys. Use those as the starter README's title and body. Do NOT paste the file contents into Bash; read it with the Read tool.
+
+## Detect repo
+
+Determine the target repository from the current working directory:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+Pass `--repo "$REPO"` to every `devwatch` command to ensure the correct repo is targeted.
+
+## Intelligence (what you decide)
+
+1. Pick a good slug. Kebab-case, short, descriptive (`dark-mode-rollout`, not `dm` or `dark_mode`). Reflects the topic, not the conclusion.
+2. Author a starter README body. Three sections, each one sentence to start — the human will expand each one when they open the file:
+   - `## Why` — the question or pain that triggered the session.
+   - `## Open Questions` — the unknowns the session needs to resolve.
+   - `## What's next` — the rough shape of the output (single feature? epic? scrapped idea?).
+3. Pick a title for the frontmatter. Title-case, short — what a reader scanning a list of sessions would scan for.
+4. If `--description` was passed inline, weave it into the `## Why` section.
+
+Pass the starter README content via a `--body-file` JSON file rather than `--body` on the command line so newlines round-trip cleanly:
+
+```bash
+BODY_FILE=$(mktemp -t devwatch-brainstorm-body-XXXX.json)
+cat > "$BODY_FILE" <<'JSON'
+{
+  "title": "<title>",
+  "body": "## Why\n\n<one sentence>\n\n## Open Questions\n\n- <bullet>\n\n## What's next\n\n<one sentence>\n"
+}
+JSON
+```
+
+## Execution
+
+```bash
+devwatch --repo "$REPO" new-brainstorm "$SLUG" \
+  --body-file "$BODY_FILE" \
+  [--epic $EPIC | --issue $ISSUE]
+```
+
+Add `--epic <N>` OR `--issue <N>` only if the user passed one (never both — they are mutually exclusive). The CLI:
+
+- Creates `documentation/project/brainstorming/<DD-MM-YY>/<SLUG>/README.md` with frontmatter (title, status=draft, linked_issues=[N] when pre-linked, else `[]`).
+- When `--epic` or `--issue` is set, appends `brainstorm: documentation/project/brainstorming/<DD-MM-YY>/<SLUG>` under the issue body's `Links:` block.
+- Fails cleanly if the folder already exists — overwriting a session is never an accident.
+
+Delete the body-file after the CLI succeeds:
+
+```bash
+rm -f "$BODY_FILE"
+```
+
+## Boundary
+
+This command creates the session scaffold. It does NOT open an issue and does NOT write code. Report the absolute session path and ask: *"Want to expand it? Open `<path>/README.md`. When the thinking converges, run `/new-feature --from-brainstorm <session>` (or `/new-bug --from-brainstorm <session>`)."*
+
+When you launched from a `--body-file`, delete the file after `devwatch new-brainstorm` succeeds:
+
+```bash
+rm -f "$BODY_FILE"
+```

--- a/.claude/skills/new-bug/SKILL.md
+++ b/.claude/skills/new-bug/SKILL.md
@@ -4,7 +4,13 @@ description: "Create a GitHub issue for a bug report."
 
 Create a GitHub issue for a bug. Record it in devwatch. Stop.
 
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill new-bug --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
 
 ## Parse arguments
 
@@ -79,7 +85,7 @@ Write a `## Failure` block at the top of the issue body with the truncated error
 
 ## Execution
 
-1. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 2. When `LINK_TO` is set, append it to `PARENTS` so the rendered body carries `child-of: #<LINK_TO>` (the CLI does the rendering — the skill just passes the parent ref through).
 

--- a/.claude/skills/new-bug/SKILL.md
+++ b/.claude/skills/new-bug/SKILL.md
@@ -14,16 +14,17 @@ The output contains every doc you must read; treat it as if you opened each file
 
 ## Parse arguments
 
-Extract description, optional run ID, optional body-file path, optional parent refs, optional scenario coordinate, and optional explicit child-of link from `$ARGUMENTS`:
-- `$ARGUMENTS` = `"login page broken"` -> DESCRIPTION="login page broken", RUN_ID=(none), PARENTS=(), FROM_SCENARIO=(none), LINK_TO=(none)
+Extract description, optional run ID, optional body-file path, optional parent refs, optional scenario coordinate, optional explicit child-of link, and optional brainstorm session from `$ARGUMENTS`:
+- `$ARGUMENTS` = `"login page broken"` -> DESCRIPTION="login page broken", RUN_ID=(none), PARENTS=(), FROM_SCENARIO=(none), LINK_TO=(none), FROM_BRAINSTORM=(none)
 - `$ARGUMENTS` = `"login page broken --run 7"` -> DESCRIPTION="login page broken", RUN_ID=7, PARENTS=()
 - `$ARGUMENTS` = `"login page broken --parent 42"` -> DESCRIPTION="login page broken", PARENTS=(42)
 - `$ARGUMENTS` = `"login page broken --parent 42 --parent 50"` -> PARENTS=(42, 50) — repeatable
 - `$ARGUMENTS` = `"login page broken --parent owner/repo#42"` -> cross-repo parent accepted
 - `$ARGUMENTS` = `"--body-file /tmp/devwatch-issue-body-XXX.json --run 7"` -> read the JSON file for the payload; no inline description
 - `$ARGUMENTS` = `'--from-scenario "smoke::e2e/smoke-chat.spec.ts::chat toggle button is visible in header" --link-to 1100'` -> FROM_SCENARIO=`<coord>`, LINK_TO=1100, no inline description (the skill prefills title + body from the failed run)
+- `$ARGUMENTS` = `"--from-brainstorm 11-05-26/login-bug-repro"` -> FROM_BRAINSTORM="11-05-26/login-bug-repro" (bare slug also accepted when unambiguous); the skill seeds the issue body from the session contents and the CLI back-links the session to the new issue in the same transaction
 
-Strip `--run <N>`, `--body-file <PATH>`, every `--parent <REF>`, `--from-scenario "<COORD>"`, and `--link-to <REF>` from the description before using it. The `<COORD>` is double-quoted because it contains `::` separators and (often) spaces in the title segment — preserve the quotes when shelling out and keep the value intact (do not split on `::` yourself; pass it through).
+Strip `--run <N>`, `--body-file <PATH>`, every `--parent <REF>`, `--from-scenario "<COORD>"`, `--link-to <REF>`, and `--from-brainstorm <SESSION>` from the description before using it. The `<COORD>` is double-quoted because it contains `::` separators and (often) spaces in the title segment — preserve the quotes when shelling out and keep the value intact (do not split on `::` yourself; pass it through).
 
 **If `--body-file <PATH>` is present:** read the file with your Read tool — it is a JSON object with the exact bytes of the request. Use its fields for the issue:
 - `description` → primary body text (verbatim, no shell quoting to worry about)
@@ -72,6 +73,16 @@ Parse the JSON response (shape: `{scenario, group, suite, last_runs: [...]}`). P
 
 Write a `## Failure` block at the top of the issue body with the truncated error message and the artifact paths. Keep it short — the goal is enough context for `/fix-issue` to start; the dashboard's scenario drawer (#1387) carries the full artifact view.
 
+## Pull brainstorm context (when `--from-brainstorm` is set)
+
+When `FROM_BRAINSTORM` is provided, the issue title and body get seeded from the session contents:
+
+```bash
+SESSION_TEXT=$(devwatch --repo "$REPO" brainstorm-read --session "$FROM_BRAINSTORM" --display)
+```
+
+The output streams every file under the session (README first, then alphabetised siblings, then subfolders) with `===== <abs path> =====` headers — the same shape as `doc-read --display`. Summarise it into the issue body — promote the `## Why` into the bug description, and any concrete repro steps from the session into the `## Steps to reproduce` block. The CLI back-links the session to the new issue automatically — do **not** write `brainstorm: <path>` into the body yourself.
+
 ## Intelligence (what you decide)
 
 1. Write a clear issue title and structured body (description, steps to reproduce, severity). When `FROM_SCENARIO` is set and the user did not pass an inline description, default the title to `Regression: <scenario.title>` and seed the body from the failure block above.
@@ -101,10 +112,11 @@ devwatch --repo "$REPO" create-issue \
   --parent <N> \
   --regression-scenario "<COORD>" \
   --epic \
+  --from-brainstorm <SESSION> \
   --run-id <RUN_ID>
 ```
 
-Add one `--parent <REF>` for each entry in `PARENTS` (repeatable). Add one `--regression-scenario "<COORD>"` for each scenario coordinate the issue should track — pass `FROM_SCENARIO` here when it is set; the flag is repeatable for issues that cover multiple regressions. Omit `--parent` entirely when `PARENTS` is empty; omit `--regression-scenario` entirely when no scenario is in scope. Omit `--run-id` if no RUN_ID was parsed from arguments. Include `--epic` only when `IS_EPIC=true`.
+Add one `--parent <REF>` for each entry in `PARENTS` (repeatable). Add one `--regression-scenario "<COORD>"` for each scenario coordinate the issue should track — pass `FROM_SCENARIO` here when it is set; the flag is repeatable for issues that cover multiple regressions. Omit `--parent` entirely when `PARENTS` is empty; omit `--regression-scenario` entirely when no scenario is in scope. Omit `--run-id` if no RUN_ID was parsed from arguments. Include `--epic` only when `IS_EPIC=true`. Include `--from-brainstorm <SESSION>` when `FROM_BRAINSTORM` is set — the CLI back-links the session to the new issue (writes `linked_issues` in the session README AND appends `brainstorm: <path>` under the issue body's `Links:` block) in the same transaction.
 
 The CLI handles everything deterministically: issue creation, labels, devwatch trace, sync. The body's `Links:` block is rendered by the CLI — it always emits a single `Links:` header followed by `- child-of: #N` lines (one per parent) and `regression-scenario: <coord>` lines (one per scenario), in that order. The body parser added in #1386 picks the regression line up on the next sync and rebuilds the `scenario_links` cache. When `--epic` is passed, the CLI also creates and pushes the `epic/<N>-<slug>` branch on origin so child issues can branch off it (see #942). The `epic` label is authoritative — GitHub is the source of truth and the server derives the `is_epic` column from the label on every sync.
 

--- a/.claude/skills/new-feature/SKILL.md
+++ b/.claude/skills/new-feature/SKILL.md
@@ -4,7 +4,13 @@ description: "Create a GitHub issue for a feature request."
 
 Create a GitHub issue for a feature. Record it in devwatch. Stop.
 
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill new-feature --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
 
 ## Parse arguments
 
@@ -53,7 +59,7 @@ Pass `--repo "$REPO"` to every `devwatch` command to ensure the correct repo is 
 
 ## Execution
 
-1. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 ```bash
 devwatch --repo "$REPO" create-issue \

--- a/.claude/skills/new-feature/SKILL.md
+++ b/.claude/skills/new-feature/SKILL.md
@@ -14,15 +14,16 @@ The output contains every doc you must read; treat it as if you opened each file
 
 ## Parse arguments
 
-Extract description, optional run ID, optional body-file path, and optional parent refs from `$ARGUMENTS`:
-- `$ARGUMENTS` = `"add dark mode"` -> DESCRIPTION="add dark mode", RUN_ID=(none), PARENTS=()
+Extract description, optional run ID, optional body-file path, optional parent refs, and optional brainstorm session from `$ARGUMENTS`:
+- `$ARGUMENTS` = `"add dark mode"` -> DESCRIPTION="add dark mode", RUN_ID=(none), PARENTS=(), FROM_BRAINSTORM=(none)
 - `$ARGUMENTS` = `"add dark mode --run 7"` -> DESCRIPTION="add dark mode", RUN_ID=7, PARENTS=()
 - `$ARGUMENTS` = `"add dark mode --parent 42"` -> PARENTS=(42)
 - `$ARGUMENTS` = `"add dark mode --parent 42 --parent 50"` -> PARENTS=(42, 50) — repeatable
 - `$ARGUMENTS` = `"add dark mode --parent owner/repo#42"` -> cross-repo parent accepted
 - `$ARGUMENTS` = `"--body-file /tmp/devwatch-issue-body-XXX.json --run 7"` -> read the JSON file for the payload; no inline description
+- `$ARGUMENTS` = `"--from-brainstorm 11-05-26/dark-mode-rollout"` -> FROM_BRAINSTORM="11-05-26/dark-mode-rollout" (bare slug also accepted when unambiguous); the skill seeds the issue body from the session contents and the CLI back-links the session to the new issue in the same transaction
 
-Strip `--run <N>`, `--body-file <PATH>`, and every `--parent <REF>` from the description before using it.
+Strip `--run <N>`, `--body-file <PATH>`, `--from-brainstorm <SESSION>`, and every `--parent <REF>` from the description before using it.
 
 **If `--body-file <PATH>` is present:** read the file with your Read tool — it is a JSON object with the exact bytes of the request. Use its fields for the feature issue:
 - `description` → primary body text (verbatim, no shell quoting to worry about)
@@ -33,6 +34,21 @@ Strip `--run <N>`, `--body-file <PATH>`, and every `--parent <REF>` from the des
 The body-file path is generated server-side and only contains filesystem-safe characters. Do NOT paste the file contents into Bash; read it with the Read tool.
 
 The CLI accepts the parent as `N`, `#N`, or `owner/repo#N`. Preserve the exact form the user typed.
+
+## Pull brainstorm context (when `--from-brainstorm` is set)
+
+When `FROM_BRAINSTORM` is provided, the issue title and body get seeded from the session contents:
+
+```bash
+SESSION_TEXT=$(devwatch --repo "$REPO" brainstorm-read --session "$FROM_BRAINSTORM" --display)
+```
+
+The output streams every file under the session (README first, then alphabetised siblings, then subfolders) with `===== <abs path> =====` headers — the same shape as `doc-read --display`. Summarise it into the issue body:
+
+1. Read the session's README (the first block in the stream) for `## Why`, `## Open Questions`, `## What's next`.
+2. Read any sibling files (notes, sketches, follow-ups) for additional context the README does not capture.
+3. Promote the `## Why` into the issue's description, and any concrete acceptance signals from the session into the `## Acceptance criteria` block.
+4. The CLI back-links the session to the new issue automatically — do **not** write `brainstorm: <path>` into the body yourself.
 
 ## Detect repo
 
@@ -70,10 +86,11 @@ devwatch --repo "$REPO" create-issue \
   --priority <P0-critical|P1-high|P2-medium|P3-low> \
   --parent <N> \
   --epic \
+  --from-brainstorm <SESSION> \
   --run-id <RUN_ID>
 ```
 
-Add one `--parent <REF>` for each entry in `PARENTS` (repeatable). Omit the flag entirely when `PARENTS` is empty. Omit `--run-id` if no RUN_ID was parsed from arguments. Include `--epic` only when `IS_EPIC=true`.
+Add one `--parent <REF>` for each entry in `PARENTS` (repeatable). Omit the flag entirely when `PARENTS` is empty. Omit `--run-id` if no RUN_ID was parsed from arguments. Include `--epic` only when `IS_EPIC=true`. Include `--from-brainstorm <SESSION>` when `FROM_BRAINSTORM` is set — the CLI back-links the session to the new issue (writes `linked_issues` in the session README AND appends `brainstorm: <path>` under the issue body's `Links:` block) in the same transaction.
 
 The CLI handles everything deterministically: issue creation, labels, devwatch trace, sync. When `--epic` is passed, the CLI also creates and pushes the `epic/<N>-<slug>` branch on origin so child issues can branch off it (see #942). The `epic` label is authoritative — GitHub is the source of truth and the server derives the `is_epic` column from the label on every sync.
 

--- a/.claude/skills/propagation-scan/SKILL.md
+++ b/.claude/skills/propagation-scan/SKILL.md
@@ -14,10 +14,13 @@ The output contains every doc you must read; treat it as if you opened each file
 
 ## Parse arguments
 
-- `$ARGUMENTS` = `"42"` → ISSUE=42, RUN_ID=(none), BASE_BRANCH=(none), CAP=5
+- `$ARGUMENTS` = `"42"` → ISSUE=42, RUN_ID=(none), BASE_BRANCH=(none), HEAD_SHA=(none), CAP=5
 - `$ARGUMENTS` = `"42 --run 7"` → ISSUE=42, RUN_ID=7
 - `$ARGUMENTS` = `"42 --run 7 --base-branch feat/364-x"` → ISSUE=42, RUN_ID=7, BASE_BRANCH=feat/364-x
+- `$ARGUMENTS` = `"42 --run 7 --base-branch local-dev-next --head 9f3a2b1"` → ISSUE=42, RUN_ID=7, BASE_BRANCH=local-dev-next, HEAD_SHA=9f3a2b1
 - `$ARGUMENTS` = `"42 --cap 3"` → CAP=3 (overrides the default top-5 cap)
+
+`--head <sha>` is set by the dispatcher when the action fires inside an `epic_integration` chain (#1916): by the time this skill runs, `merge-to-epic` and `delete-branch` have already destroyed the feature branch, so a working-tree diff would be empty. The flag pins the diff to the implement run's tip — the same diff every time, regardless of where HEAD now sits.
 
 ## Detect repo
 
@@ -33,7 +36,7 @@ Pass `--repo "$REPO"` to every `devwatch` and `gh` command.
 git branch --show-current
 ```
 
-If RUN_ID is present, skip branch-name validation — the dashboard resolved the branch. Otherwise require the branch to start with `fix/<ISSUE>-`, `feat/<ISSUE>-`, `refactor/<ISSUE>-`, `chore/<ISSUE>-`, or `docs/<ISSUE>-`. If not, stop and tell the user:
+If RUN_ID or HEAD_SHA is present, skip branch-name validation — the dispatcher resolved the diff coordinates and the working tree is no longer authoritative. Otherwise require the branch to start with `fix/<ISSUE>-`, `feat/<ISSUE>-`, `refactor/<ISSUE>-`, `chore/<ISSUE>-`, or `docs/<ISSUE>-`. If not, stop and tell the user:
 
 > "Current branch `<branch>` does not belong to issue #<ISSUE>. Check out the correct branch first."
 
@@ -45,8 +48,14 @@ The mandatory-reads block already loaded the authoritative `propagation-scan` ru
 
 ```bash
 BASE="${BASE_BRANCH:-$(devwatch --repo "$REPO" branches dev)}"
-git diff "origin/${BASE}...HEAD"
+if [ -n "$HEAD_SHA" ]; then
+  git diff "origin/${BASE}...${HEAD_SHA}"
+else
+  git diff "origin/${BASE}...HEAD"
+fi
 ```
+
+When `--head <sha>` is supplied the diff is pinned to that SHA — deterministic across re-runs and immune to checkout state. The implement run's tip SHA is recorded on the `agent_runs` row by `/fix-issue` / `/feat-issue`; the dispatcher resolves it at trigger time and passes it here.
 
 If the diff is empty, purely cosmetic (formatting or import reorder), or limited to a dependency bump (`uv.lock`, `package-lock.json`, `package.json` deps), emit `status: skipped` with a reason and stop.
 

--- a/.claude/skills/propagation-scan/SKILL.md
+++ b/.claude/skills/propagation-scan/SKILL.md
@@ -4,8 +4,13 @@ description: "Scan the codebase for sites where the current diff's change could 
 
 After a fix or feature lands, find every other site where the same change could apply — and file each site as its own tracked unit of work. File-only: never edits code, never commits, never opens a PR.
 
-Authoritative rule: `docs:general/propagation-scan`.
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill propagation-scan --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done. The mandatory-reads include the authoritative `propagation-scan` rule — that doc is loaded once here and referenced (not re-read) throughout the rest of this skill.
 
 ## Parse arguments
 
@@ -32,9 +37,9 @@ If RUN_ID is present, skip branch-name validation — the dashboard resolved the
 
 > "Current branch `<branch>` does not belong to issue #<ISSUE>. Check out the correct branch first."
 
-## 2. Read the rule
+## 2. Apply the rule
 
-Load `docs:general/propagation-scan`. That file is the authority on when propagation applies, when to skip, the file-only boundary, the cap, and the human gate. Evaluate the current diff against it; if the rule says "skip," emit `status: skipped` with the reason and stop.
+The mandatory-reads block already loaded the authoritative `propagation-scan` rule — the source of truth on when propagation applies, when to skip, the file-only boundary, the cap, and the human gate. Evaluate the current diff against it; if the rule says "skip," emit `status: skipped` with the reason and stop.
 
 ## 3. Gather the diff
 
@@ -115,7 +120,7 @@ Agent-to-agent confirmation is not sufficient for this skill. Filing issues has 
 
 ## 8. Execute — file issues
 
-1. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 For each approved opportunity, create a child-of-`<ISSUE>` issue:
 
@@ -148,7 +153,7 @@ Surfaced by `/propagation-scan` on #<ISSUE>.
 
 ## Why this is tracked, not inlined
 
-The originating PR is scoped to #<ISSUE>. This site is a candidate for the same treatment but belongs in its own branch and review. See `docs:general/propagation-scan` for the rule.
+The originating PR is scoped to #<ISSUE>. This site is a candidate for the same treatment but belongs in its own branch and review. See the propagation-scan rule.
 ```
 
 **Priority** defaults to `P3-low` (opportunistic, not blocking). Escalate to `P2-medium` when the originating kind is `bugfix_shape` — a bug pattern that recurs is higher-signal than a helper opportunity.
@@ -171,7 +176,7 @@ devwatch --repo "$REPO" agent-comment \
 - #<N3> — <summary>
 
 Cap: <CAP>. Overflow: <K>.
-See \`docs:general/propagation-scan\` for the rule."
+See the propagation-scan rule."
 ```
 
 ## 10. Record completion

--- a/.claude/skills/propagation-scan/SKILL.md
+++ b/.claude/skills/propagation-scan/SKILL.md
@@ -141,8 +141,28 @@ devwatch --repo "$REPO" create-issue \
   --area <area> \
   --priority <P2-medium|P3-low> \
   --parent <ISSUE> \
-  --run-id <RUN_ID>
+  --run-id <RUN_ID> \
+  --no-claim-run
 ```
+
+`--no-claim-run` is mandatory here. This skill files several issues
+against one `--run-id`; without the flag each `create-issue` would
+overwrite the run's `github_issue`/`summary` and the run row would end
+up pointing at the last child instead of the scan target. The run's
+terminal status/summary is owned by the step-10 `agent-update` below —
+written once, not re-stamped per child.
+
+**Title format:** every propagation issue title is `propagation: <one-line summary>` — the `propagation:` prefix exactly once, then the candidate's one-line summary. No other prefix, no descriptive-only title.
+
+**Exactly one `--parent`, and it is the scan target.** `--parent <ISSUE>` appears **exactly once** in the invocation; `<ISSUE>` is the scan target passed in `$ARGUMENTS` — nothing else. `devwatch create-issue --parent` accepts the flag multiple times, but propagation-scan never passes it twice. A propagation issue is a sibling of exactly one originating issue; its parent is the scan target — full stop. This is the authoritative single-parent rule from the `propagation-scan` rule doc loaded in the mandatory reads — do not restate or reinterpret it, follow it.
+
+Do **not**:
+
+- pass the scan target's epic as a `--parent`,
+- pass the workflow root (or any workflow the scan target is a step in) as a `--parent`,
+- walk the `child-of` chain upward and add any ancestor as a `--parent`.
+
+The scan target's epic, parent, ancestors, and the workflow it belongs to are *organisation* — how the scan target is filed — not *parentage* of the propagation child. The forbidden move is the ancestor-walk: seeing an epic or workflow root "in scope" and helpfully linking it too. Every filed issue carries exactly one `child-of`, the scan target — never zero, never more than one.
 
 Issue body template:
 
@@ -171,7 +191,24 @@ The originating PR is scoped to #<ISSUE>. This site is a candidate for the same 
 
 After each `create-issue`, note the returned issue number — you need them for the summary.
 
-## 9. Summary comment
+## 9. Verify the filed issues
+
+Before posting the summary, read back **every** issue created in step 8 and assert it matches the contract. This is the structural backstop — prose guidance has demonstrably drifted, so the agent verifies its own output rather than declaring success on trust.
+
+For each filed issue number `<N>`:
+
+```bash
+gh issue view <N> --repo "$REPO" --json number,labels,body
+```
+
+Assert both of the following:
+
+1. **Exactly one `child-of` link, and it is the scan target.** Parse the `Links:` section of the body — there must be exactly one `child-of: #<M>` line and `<M>` must equal `<ISSUE>`. Zero `child-of` links (missing-link defect) and more than one (excess-link defect, e.g. the scan target's epic or workflow root walked in) both fail.
+2. **Not labelled `epic`.** The `epic` label must not appear on the issue. A propagation child is a flat child of the scan target, never an umbrella.
+
+If **any** filed issue fails either assertion, do not post the summary and do not record completion as `completed`. Emit `status: failed`, naming every offending issue number and which assertion it broke, and stop. A run that filed issues violating the contract is a failed run, not a completed one — the human needs the issue numbers to remediate.
+
+## 10. Summary comment
 
 Post a single summary comment on the parent `<ISSUE>`:
 
@@ -188,7 +225,7 @@ Cap: <CAP>. Overflow: <K>.
 See the propagation-scan rule."
 ```
 
-## 10. Record completion
+## 11. Record completion
 
 Update the agent-run trace (use `--run-id` if available, otherwise `--issue`):
 
@@ -215,3 +252,5 @@ devwatch --repo "$REPO" agent-update \
 - **Capped.** Top `CAP` opportunities (default 5). Overflow counted, not filed.
 - **Human-gated.** The user approves the opportunity list before any issue is created.
 - **No cross-skill writes.** Does not write rules, docs, or code. `/issue-to-rule` handles rules; `/add-documentation` handles docs.
+- **Never creates an epic.** The skill files **flat** `child-of` children of the scan target. It never passes `--epic`, never files an umbrella / epic issue, and never re-roots the filed children under a new parent. If the candidate count exceeds the cap, the overflow is **counted in the summary** (step 10) — it is never absorbed by inventing an epic to hold the extra issues.
+- **Never touches a pre-existing issue.** The skill only **creates new** flat children of the scan target. It never modifies, re-links, re-titles, re-parents, re-labels, or closes an issue that already exists — including issues filed by an *earlier* propagation run. Each run owns only the issues it creates in step 8.

--- a/.claude/skills/propagation-scan/SKILL.md
+++ b/.claude/skills/propagation-scan/SKILL.md
@@ -131,9 +131,30 @@ Agent-to-agent confirmation is not sufficient for this skill. Filing issues has 
 
 1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
-For each approved opportunity, create a child-of-`<ISSUE>` issue:
+2. Resolve the scan target's epic **once**, before the filing loop:
 
 ```bash
+EPIC=$(devwatch --repo "$REPO" epic-parent --issue <ISSUE>)
+```
+
+`epic-parent` walks the scan target's `child-of` chain and prints the nearest ancestor carrying the `epic` label, or an empty string when the scan target has no epic. The epic is a property of the scan target, not of the candidate site — resolve it once and reuse `$EPIC` for every issue this run files.
+
+For each approved opportunity, create the issue. The `--parent` flags depend on whether the scan target has an epic — when `$EPIC` is non-empty, pass it as a second `--parent`:
+
+```bash
+# Scan target has an epic ($EPIC is non-empty) — two --parent flags:
+devwatch --repo "$REPO" create-issue \
+  --type feature \
+  --title "propagation: <one-line summary>" \
+  --body "<markdown body>" \
+  --area <area> \
+  --priority <P2-medium|P3-low> \
+  --parent <ISSUE> \
+  --parent "$EPIC" \
+  --run-id <RUN_ID> \
+  --no-claim-run
+
+# Scan target has no epic ($EPIC is empty) — one --parent flag:
 devwatch --repo "$REPO" create-issue \
   --type feature \
   --title "propagation: <one-line summary>" \
@@ -154,15 +175,15 @@ written once, not re-stamped per child.
 
 **Title format:** every propagation issue title is `propagation: <one-line summary>` — the `propagation:` prefix exactly once, then the candidate's one-line summary. No other prefix, no descriptive-only title.
 
-**Exactly one `--parent`, and it is the scan target.** `--parent <ISSUE>` appears **exactly once** in the invocation; `<ISSUE>` is the scan target passed in `$ARGUMENTS` — nothing else. `devwatch create-issue --parent` accepts the flag multiple times, but propagation-scan never passes it twice. A propagation issue is a sibling of exactly one originating issue; its parent is the scan target — full stop. This is the authoritative single-parent rule from the `propagation-scan` rule doc loaded in the mandatory reads — do not restate or reinterpret it, follow it.
+**Parentage — the scan target, plus its epic when it has one.** Every propagation issue carries `--parent <ISSUE>` — the scan target passed in `$ARGUMENTS` — and that link is **never** omitted. When `epic-parent` resolved a non-empty `$EPIC`, the issue **also** carries `--parent "$EPIC"` so it groups beside the epic's other children in the issue tree instead of sitting one hop below them. When `$EPIC` is empty, the scan-target link stands alone. This is the authoritative parentage rule from the `propagation-scan` rule doc loaded in the mandatory reads — do not restate or reinterpret it, follow it.
 
 Do **not**:
 
-- pass the scan target's epic as a `--parent`,
-- pass the workflow root (or any workflow the scan target is a step in) as a `--parent`,
-- walk the `child-of` chain upward and add any ancestor as a `--parent`.
+- pass any `--parent` other than the scan target and its resolved epic — no non-epic intermediate ancestor, no second epic deeper in the chain,
+- pass the workflow root (or any workflow the scan target is a step in) as a `--parent` — the workflow is execution metadata, not issue-tree parentage,
+- omit `--parent <ISSUE>` — the scan-target link is always present, even when the `$EPIC` link is added alongside it.
 
-The scan target's epic, parent, ancestors, and the workflow it belongs to are *organisation* — how the scan target is filed — not *parentage* of the propagation child. The forbidden move is the ancestor-walk: seeing an epic or workflow root "in scope" and helpfully linking it too. Every filed issue carries exactly one `child-of`, the scan target — never zero, never more than one.
+The scan target records *why* the issue exists; its epic records *where the work groups*. Those are the only two `child-of` links a propagation issue may carry. The forbidden move is walking the `child-of` chain *past* the epic — onto a non-epic ancestor, a deeper epic, or workflow structure — and helpfully linking it too.
 
 Issue body template:
 
@@ -203,8 +224,11 @@ gh issue view <N> --repo "$REPO" --json number,labels,body
 
 Assert both of the following:
 
-1. **Exactly one `child-of` link, and it is the scan target.** Parse the `Links:` section of the body — there must be exactly one `child-of: #<M>` line and `<M>` must equal `<ISSUE>`. Zero `child-of` links (missing-link defect) and more than one (excess-link defect, e.g. the scan target's epic or workflow root walked in) both fail.
-2. **Not labelled `epic`.** The `epic` label must not appear on the issue. A propagation child is a flat child of the scan target, never an umbrella.
+1. **The `child-of` set is exactly the scan target, plus its epic if it has one.** Parse the `Links:` section of the body and collect every `child-of: #<M>` line:
+   - `<ISSUE>` (the scan target) **must** be present. Zero `child-of` links is the missing-link defect.
+   - `$EPIC` (the epic resolved in step 8) **must** be present if and only if `epic-parent` returned a non-empty value. When the scan target has no epic, the scan-target link is the only link.
+   - **No other** `child-of` link may appear — a non-epic intermediate ancestor, a second epic deeper in the chain, or a workflow root is the excess-link defect.
+2. **Not labelled `epic`.** The `epic` label must not appear on the issue. A propagation child is a flat child, never an umbrella.
 
 If **any** filed issue fails either assertion, do not post the summary and do not record completion as `completed`. Emit `status: failed`, naming every offending issue number and which assertion it broke, and stop. A run that filed issues violating the contract is a failed run, not a completed one — the human needs the issue numbers to remediate.
 

--- a/.claude/skills/propagation-scan/SKILL.md
+++ b/.claude/skills/propagation-scan/SKILL.md
@@ -131,30 +131,9 @@ Agent-to-agent confirmation is not sufficient for this skill. Filing issues has 
 
 1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
-2. Resolve the scan target's epic **once**, before the filing loop:
+2. For each approved opportunity, create the issue. Pass exactly one `--parent` — the scan target from `$ARGUMENTS`:
 
 ```bash
-EPIC=$(devwatch --repo "$REPO" epic-parent --issue <ISSUE>)
-```
-
-`epic-parent` walks the scan target's `child-of` chain and prints the nearest ancestor carrying the `epic` label, or an empty string when the scan target has no epic. The epic is a property of the scan target, not of the candidate site — resolve it once and reuse `$EPIC` for every issue this run files.
-
-For each approved opportunity, create the issue. The `--parent` flags depend on whether the scan target has an epic — when `$EPIC` is non-empty, pass it as a second `--parent`:
-
-```bash
-# Scan target has an epic ($EPIC is non-empty) — two --parent flags:
-devwatch --repo "$REPO" create-issue \
-  --type feature \
-  --title "propagation: <one-line summary>" \
-  --body "<markdown body>" \
-  --area <area> \
-  --priority <P2-medium|P3-low> \
-  --parent <ISSUE> \
-  --parent "$EPIC" \
-  --run-id <RUN_ID> \
-  --no-claim-run
-
-# Scan target has no epic ($EPIC is empty) — one --parent flag:
 devwatch --repo "$REPO" create-issue \
   --type feature \
   --title "propagation: <one-line summary>" \
@@ -170,20 +149,20 @@ devwatch --repo "$REPO" create-issue \
 against one `--run-id`; without the flag each `create-issue` would
 overwrite the run's `github_issue`/`summary` and the run row would end
 up pointing at the last child instead of the scan target. The run's
-terminal status/summary is owned by the step-10 `agent-update` below —
+terminal status/summary is owned by the step-9 `agent-update` below —
 written once, not re-stamped per child.
 
 **Title format:** every propagation issue title is `propagation: <one-line summary>` — the `propagation:` prefix exactly once, then the candidate's one-line summary. No other prefix, no descriptive-only title.
 
-**Parentage — the scan target, plus its epic when it has one.** Every propagation issue carries `--parent <ISSUE>` — the scan target passed in `$ARGUMENTS` — and that link is **never** omitted. When `epic-parent` resolved a non-empty `$EPIC`, the issue **also** carries `--parent "$EPIC"` so it groups beside the epic's other children in the issue tree instead of sitting one hop below them. When `$EPIC` is empty, the scan-target link stands alone. This is the authoritative parentage rule from the `propagation-scan` rule doc loaded in the mandatory reads — do not restate or reinterpret it, follow it.
+**Parentage — pass only the scan target; `create-issue` derives the epic edge.** Every propagation issue carries `--parent <ISSUE>` — the scan target — and that is the **only** `--parent` you pass. When the scan target is itself a child of an epic, `create-issue` walks the scan target's `child-of` chain in code and writes the `child-of: <epic>` edge for you, so the issue groups beside the epic's other children instead of sitting one hop below them (#2095). You do **not** resolve the epic, and you do **not** pass it as a second `--parent` — the epic edge is a deterministic property of issue creation, not something the skill assembles per run.
 
 Do **not**:
 
-- pass any `--parent` other than the scan target and its resolved epic — no non-epic intermediate ancestor, no second epic deeper in the chain,
+- pass any `--parent` other than the scan target — not the resolved epic (`create-issue` adds it), not a non-epic intermediate ancestor, not a second epic deeper in the chain,
 - pass the workflow root (or any workflow the scan target is a step in) as a `--parent` — the workflow is execution metadata, not issue-tree parentage,
-- omit `--parent <ISSUE>` — the scan-target link is always present, even when the `$EPIC` link is added alongside it.
+- omit `--parent <ISSUE>` — the scan-target link is always present.
 
-The scan target records *why* the issue exists; its epic records *where the work groups*. Those are the only two `child-of` links a propagation issue may carry. The forbidden move is walking the `child-of` chain *past* the epic — onto a non-epic ancestor, a deeper epic, or workflow structure — and helpfully linking it too.
+The scan target records *why* the issue exists; its epic records *where the work groups*. Those are the only two `child-of` links a propagation issue may carry — and `create-issue` is the single thing that assembles them.
 
 Issue body template:
 
@@ -212,27 +191,9 @@ The originating PR is scoped to #<ISSUE>. This site is a candidate for the same 
 
 After each `create-issue`, note the returned issue number — you need them for the summary.
 
-## 9. Verify the filed issues
+The `child-of` set is **not** something the skill assembles or self-verifies any more. `create-issue` writes the scan-target edge and — when the scan target has an epic — the epic edge, both in code (#2095). There is no per-run conditional for an agent to skip and no blind re-read for it to rubber-stamp: a missing or wrong `child-of` set is now a `create-issue` bug, caught by that command's own tests, not a propagation-scan responsibility.
 
-Before posting the summary, read back **every** issue created in step 8 and assert it matches the contract. This is the structural backstop — prose guidance has demonstrably drifted, so the agent verifies its own output rather than declaring success on trust.
-
-For each filed issue number `<N>`:
-
-```bash
-gh issue view <N> --repo "$REPO" --json number,labels,body
-```
-
-Assert both of the following:
-
-1. **The `child-of` set is exactly the scan target, plus its epic if it has one.** Parse the `Links:` section of the body and collect every `child-of: #<M>` line:
-   - `<ISSUE>` (the scan target) **must** be present. Zero `child-of` links is the missing-link defect.
-   - `$EPIC` (the epic resolved in step 8) **must** be present if and only if `epic-parent` returned a non-empty value. When the scan target has no epic, the scan-target link is the only link.
-   - **No other** `child-of` link may appear — a non-epic intermediate ancestor, a second epic deeper in the chain, or a workflow root is the excess-link defect.
-2. **Not labelled `epic`.** The `epic` label must not appear on the issue. A propagation child is a flat child, never an umbrella.
-
-If **any** filed issue fails either assertion, do not post the summary and do not record completion as `completed`. Emit `status: failed`, naming every offending issue number and which assertion it broke, and stop. A run that filed issues violating the contract is a failed run, not a completed one — the human needs the issue numbers to remediate.
-
-## 10. Summary comment
+## 9. Summary comment
 
 Post a single summary comment on the parent `<ISSUE>`:
 
@@ -249,7 +210,7 @@ Cap: <CAP>. Overflow: <K>.
 See the propagation-scan rule."
 ```
 
-## 11. Record completion
+## 10. Record completion
 
 Update the agent-run trace (use `--run-id` if available, otherwise `--issue`):
 
@@ -276,5 +237,5 @@ devwatch --repo "$REPO" agent-update \
 - **Capped.** Top `CAP` opportunities (default 5). Overflow counted, not filed.
 - **Human-gated.** The user approves the opportunity list before any issue is created.
 - **No cross-skill writes.** Does not write rules, docs, or code. `/issue-to-rule` handles rules; `/add-documentation` handles docs.
-- **Never creates an epic.** The skill files **flat** `child-of` children of the scan target. It never passes `--epic`, never files an umbrella / epic issue, and never re-roots the filed children under a new parent. If the candidate count exceeds the cap, the overflow is **counted in the summary** (step 10) — it is never absorbed by inventing an epic to hold the extra issues.
+- **Never creates an epic.** The skill files **flat** `child-of` children of the scan target. It never passes `--epic`, never files an umbrella / epic issue, and never re-roots the filed children under a new parent. If the candidate count exceeds the cap, the overflow is **counted in the summary** (step 9) — it is never absorbed by inventing an epic to hold the extra issues.
 - **Never touches a pre-existing issue.** The skill only **creates new** flat children of the scan target. It never modifies, re-links, re-titles, re-parents, re-labels, or closes an issue that already exists — including issues filed by an *earlier* propagation run. Each run owns only the issues it creates in step 8.

--- a/.claude/skills/run-acceptance/SKILL.md
+++ b/.claude/skills/run-acceptance/SKILL.md
@@ -58,35 +58,32 @@ probes the baseURL itself; if you know the app is down, start it first
 
 ## Run
 
-The skill bundles every coordinate into a single ``devwatch scenarios
-run`` call so PW dedupes specs internally and the gate stays one
-terminal flow. Each coordinate's spec file becomes a positional
-argument to ``npx playwright test``.
+The skill passes every coordinate verbatim to ``devwatch scenarios
+run-many``. The CLI extracts each coordinate's ``<file>`` segment for
+PW's spec-path argument list (deduped so PW sees each file once) and
+keeps the full coordinate around so the per-scenario run row carries
+``target_kind=scenario,target_id=<scenario id>`` — the only shape that
+refreshes the dashboard pill and the acceptance gate's per-scenario
+``last_run_status``/``last_run_commit_sha`` columns (#1848).
 
 ```bash
-SPECS=()
-for COORD in "${COORDS[@]}"; do
-  # Coordinate is <suite>::<file>::<title> — extract the file segment.
-  SPEC="$(echo "$COORD" | awk -F'::' '{print $2}')"
-  SPECS+=("$SPEC")
-done
-
-# Deduplicate spec paths so PW sees each file once.
-mapfile -t UNIQUE_SPECS < <(printf '%s\n' "${SPECS[@]}" | sort -u)
-
-devwatch --repo "$REPO" scenarios run-many "${UNIQUE_SPECS[@]}"
+devwatch --repo "$REPO" scenarios run-many "${COORDS[@]}"
 ```
 
 The CLI:
 
-- Resolves each spec path against the repo's PW config.
+- Resolves every coordinate to its active scenario row via
+  ``POST /api/scenarios/resolve-coordinate``. A coord that doesn't
+  resolve hard-fails with a "re-sync the catalogue" message.
 - Spawns one ``npx playwright test <spec1> <spec2> … --reporter=json``
-  invocation. PW dedupes internally; running the same suite twice is a
-  no-op.
+  invocation. PW dedupes specs internally; running the same suite
+  twice is a no-op.
 - Records ``commit_sha = git rev-parse HEAD`` so the dispatcher's
   classifier can compare against the workflow branch's HEAD.
-- POSTs each scenario's result row to ``/api/scenarios/runs`` so the
-  dashboard pill and the gate's truth source share one write site.
+- Parses the PW JSON reporter, matches each per-test result back to
+  its coordinate by ``(projectName, file, title)``, and POSTs one
+  ``target_kind=scenario`` row per coord to ``/api/scenarios/runs`` so
+  the dashboard pill and the gate's truth source share one write site.
 
 The command exits ``0`` on a green run and non-zero on red.
 

--- a/.claude/skills/run-acceptance/SKILL.md
+++ b/.claude/skills/run-acceptance/SKILL.md
@@ -12,6 +12,14 @@ Boundary: this skill **runs** the acceptance scenarios — it does not
 file bugs, edit issues, or open PRs. Use ``/new-bug --from-scenario``
 for regression bugs and ``/submit-pr`` for the workflow PR.
 
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill run-acceptance --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done. The mandatory-reads include the authoritative `acceptance-scenarios` doc — the contract this skill enforces as the workflow's pre-PR gate, including the title-stability invariant and the regression-vs-acceptance distinction.
+
 ## Detect repo
 
 ```bash

--- a/.claude/skills/run-scenarios/SKILL.md
+++ b/.claude/skills/run-scenarios/SKILL.md
@@ -19,10 +19,21 @@ The output contains every doc you must read; treat it as if you opened each file
 
 Extract `TARGET` from `$ARGUMENTS`. Examples:
 
-- `e2e/smoke-chat.spec.ts` → spec path, runs the whole file.
-- `123` → numeric scenario id, runs that one test (looked up via the
-  scenario catalogue).
+- `123` → numeric scenario id (the dashboard's per-row Run button always
+  passes this shape — the catalogue already pinned the id at click
+  time). Forward as `--id 123` so the CLI skips coord parsing entirely.
+- `--spec e2e/login.spec.ts` → spec-scoped run (#1860). Runs every
+  active scenario under that file as one Playwright invocation and
+  records one `target_kind='scenario'` row per scenario id so each pill
+  on the workflow Acceptance panel flips independently. Used by the
+  panel's per-file "Run spec" button when ordering-dependent tests
+  (test 2 needs test 1's setup) must execute together.
 - `smoke::e2e/login.spec.ts::logs in` → coordinate `<suite>::<file>::<title>`.
+  Operator-only escape hatch — use the id form when the dashboard
+  surfaces one.
+- `e2e/smoke-chat.spec.ts` → spec path positional, runs the whole file
+  but records one `target_kind='suite'` row (operator escape hatch
+  only). Prefer `--spec <path>` when you want per-pill refresh.
 
 Optional flags forwarded to the CLI:
 
@@ -55,8 +66,22 @@ Pass `--repo "$REPO"` to every `devwatch` command.
 
 ## Run
 
+A purely-numeric `$TARGET` is a scenario id; pass it through `--id` so
+the CLI dispatches via the per-id service path without trying to parse
+it as a coordinate. A `$TARGET` starting with `--spec ` (the workflow
+Acceptance panel's "Run spec" button) is forwarded verbatim so the CLI
+runs the whole spec and writes per-scenario rows. Anything else
+(coordinate / bare spec path) goes through the positional form.
+
 ```bash
-devwatch --repo "$REPO" scenarios run "$TARGET"
+if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
+  devwatch --repo "$REPO" scenarios run --id "$TARGET"
+elif [[ "$TARGET" == --spec\ * ]]; then
+  # shellcheck disable=SC2086 — splitting --spec from its path is intentional.
+  devwatch --repo "$REPO" scenarios run $TARGET
+else
+  devwatch --repo "$REPO" scenarios run "$TARGET"
+fi
 ```
 
 The CLI:

--- a/.claude/skills/run-scenarios/SKILL.md
+++ b/.claude/skills/run-scenarios/SKILL.md
@@ -7,6 +7,14 @@ spawns Playwright, copies artifacts, and POSTs the run row through the local
 lingtai server (the server is the single SQLite writer). This skill is a thin
 wrapper that interprets the result and offers next steps.
 
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill run-scenarios --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done. The mandatory-reads include the authoritative `acceptance-scenarios` doc — the contract for the `<suite>::<file>::<title>` coordinate this skill accepts as a target, plus the title-stability invariant.
+
 ## Parse arguments
 
 Extract `TARGET` from `$ARGUMENTS`. Examples:

--- a/.claude/skills/scaffold-scenarios/SKILL.md
+++ b/.claude/skills/scaffold-scenarios/SKILL.md
@@ -74,9 +74,15 @@ fi
 
 For each pending draft:
 
-1. Suggest a default spec path (`e2e/<slug>.spec.ts` under the
+1. Suggest a default spec path (`<slug>.spec.ts` directly under the
    configured suite cwd). The suite cwd lives in
-   `~/.devwatch/projects/<project>.yaml` under `repos[].scenarios.cwd`.
+   `~/.devwatch/projects/<project>.yaml` under `repos[].scenarios.cwd`
+   and is the directory where `npx playwright test --list` is invoked,
+   so file paths Playwright reports are already relative to it.
+   Different watched repos place specs differently (some under `e2e/`,
+   some under `tests/`, some directly under the suite cwd) — pick the
+   default that matches your Playwright config and override per draft
+   when needed.
 2. Allow the user to override the path before any file is written.
 3. Append a `test.skip("<title>", async ({ page }) => { /* TODO #N */ });`
    block to the chosen file, creating the file (with the right import)
@@ -130,7 +136,12 @@ import_line = "import { test } from '@playwright/test';\n"
 scaffolded = []
 for draft in pending:
     title = draft["title"]
-    suggested = base_dir / "e2e" / f"{slugify(title)}.spec.ts"
+    # Default to ``<suite_cwd>/<slug>.spec.ts``. The suite cwd is
+    # already the directory Playwright runs from, so file paths
+    # in the catalogue are relative to it; an extra ``e2e/`` segment
+    # would mismatch repos whose Playwright config places specs
+    # elsewhere (#1769).
+    suggested = base_dir / f"{slugify(title)}.spec.ts"
     spec_path = Path(os.environ.get("SCAFFOLD_OVERRIDE_PATH") or suggested)
     spec_path.parent.mkdir(parents=True, exist_ok=True)
     if spec_path.exists():

--- a/.claude/skills/scaffold-scenarios/SKILL.md
+++ b/.claude/skills/scaffold-scenarios/SKILL.md
@@ -17,6 +17,14 @@ issue bodies — bind-on-sync rewrites
 once the real test exists. To add or remove draft lines on the issue
 itself, use `/edit-acceptance-scenarios`.
 
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill scaffold-scenarios --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done. The mandatory-reads include the authoritative `acceptance-scenarios` doc — the contract for the `Links:` section, the `<suite>::<file>::<title>` coordinate, the title-stability invariant, and the draft lifecycle this skill is one step of.
+
 ## Parse arguments
 
 ```bash

--- a/.claude/skills/submit-epic-pr/SKILL.md
+++ b/.claude/skills/submit-epic-pr/SKILL.md
@@ -1,0 +1,64 @@
+---
+description: "Open the epic-level PR for an epic-rooted workflow."
+---
+
+Open the epic PR for an epic-rooted workflow (#1884). Wraps the same `gh pr create` + closes-trailer body + `workflows.pr_number` write that used to run in-process — moved into a skill so the dashboard's inline terminal opens like every other workflow / step action.
+
+The readiness gate has already run on the server before this skill launched; if you got here, every child is closed on GitHub and present on the epic / shared branch. Do not re-prompt the user.
+
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill submit-epic-pr --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
+
+## Parse arguments
+
+`$ARGUMENTS` shape:
+
+```
+<epic> --workflow-id <id> [--run <run_id>]
+```
+
+Examples:
+
+- `185 --workflow-id 18 --run 42` → open the epic PR for epic #185 on workflow 18, attach to agent-run 42.
+
+Extract `EPIC` (positional, integer), `WORKFLOW_ID` (`--workflow-id <id>`), and `RUN_ID` (`--run <id>`).
+
+If `WORKFLOW_ID` is missing, **stop** — this skill is only for workflow-bound submissions launched from the dashboard. The legacy CLI path (no workflow id) is for direct ad-hoc use, not the dashboard chip.
+
+## Detect repo
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+Pass `--repo "$REPO"` to every `devwatch` command.
+
+## Execution
+
+Hand the work to the existing CLI — it dispatches on workflow shape (EPIC_INTEGRATION vs SAME/batch), composes the closes-trailer body, runs `gh pr create`, writes `workflows.pr_number`, and updates the agent run row:
+
+```bash
+devwatch --repo "$REPO" submit-epic-pr "$EPIC" \
+  --workflow-id "$WORKFLOW_ID" \
+  --run-id "$RUN_ID"
+```
+
+Omit `--run-id` if no `RUN_ID` was parsed.
+
+The CLI prints the PR URL, the shipped-child list, and the agent-run id. Surface those lines to the user verbatim — they are the only acknowledgement the user gets that the click did something.
+
+### What the CLI does (so you can explain failures)
+
+- **EPIC_INTEGRATION shape**: PR head = `epic/<N>-<slug>` (the epic integration branch), PR base = repo dev branch. Body lists `Closes #<root>` plus `Closes #<child>` per shipped child.
+- **SAME/batch shape**: PR head = `workflow.base_branch` (the shared branch every step landed on), PR base = repo dev branch. Body lists `Closes` lines for the root epic and every `done` step.
+
+Both shapes label the PR `epic` and write `workflows.pr_number` so the dashboard's `submit-workflow-pr` chip flips to `done` and **Merge PR** unblocks.
+
+## Boundary
+
+This skill opens the PR. It does not merge, does not run `/release`, and does not file follow-up issues. Tell the user the next step is to wait for CI green, then run `/merge-pr` (or click the workflow chip).

--- a/.claude/skills/submit-pr/SKILL.md
+++ b/.claude/skills/submit-pr/SKILL.md
@@ -4,7 +4,13 @@ description: "Submit the current branch as a PR."
 
 Wrap up a branch: commit, push, create PR, record trace.
 
-GitHub writing rules: `docs:general/github-writing`.
+## Mandatory reads — do this first
+
+Run:
+
+    devwatch --repo "$REPO" doc-read --skill submit-pr --display
+
+The output contains every doc you must read; treat it as if you opened each file directly. Do not proceed with the skill body until done.
 
 ## Parse arguments
 
@@ -64,7 +70,7 @@ devwatch --repo "$REPO" issue-history <ISSUE>
 
 ## Execution
 
-1. Read `docs:general/github-writing` — banned tokens, no personal data, per-artifact skeletons. Apply to every title, body, and comment below.
+1. Apply the GitHub-writing rules from the mandatory-reads block (banned tokens, no personal data, per-artifact skeletons) to every title, body, and comment below.
 
 ```bash
 devwatch --repo "$REPO" submit-pr \

--- a/documentation/general/general/checklist.md
+++ b/documentation/general/general/checklist.md
@@ -1,3 +1,9 @@
+---
+mandatory_for:
+  universal: true
+  rules: [critical]
+---
+
 # Completion Checklist
 
 Run through this checklist before marking any task as done. Every item is a yes/no question. If you are unsure about a check, follow the link to the full rule.
@@ -10,6 +16,7 @@ This is the general checklist — language-agnostic. After this, run the languag
 
 - [ ] Every change traces back to the issue. No extra features, no drive-by refactors, no "while I'm here" additions. → [No Shortcuts](clean-code#2-no-shortcuts)
 - [ ] No unrelated files modified. If you found something else to fix, create a separate issue. → [No Shortcuts](clean-code#2-no-shortcuts)
+- [ ] Propagation decision made. If the diff adds a helper, pattern, perf fix, or bug-fix shape, run `/propagation-scan` to file sibling sites as their own issues. If the diff is purely local, cosmetic, or a dependency bump, skip the scan. → [Propagation scan](propagation-scan)
 
 ## Code Quality
 

--- a/documentation/general/general/clean-code.md
+++ b/documentation/general/general/clean-code.md
@@ -1,3 +1,9 @@
+---
+mandatory_for:
+  universal: true
+  rules: [critical]
+---
+
 # Clean Code
 
 The principles that guide every decision. Language-agnostic, framework-agnostic. Read once, apply everywhere.

--- a/documentation/general/general/documentation-checklist.md
+++ b/documentation/general/general/documentation-checklist.md
@@ -1,9 +1,16 @@
+---
+mandatory_for:
+  skills: [add-documentation]
+---
+
 # Documentation Checklist
 
 Run through this checklist after updating documentation. Used by the `/add-documentation` skill as a quality gate.
 
-For documentation principles, read [Documentation](documentation).
-For project-specific doc mapping, read `docs:project/core-app/documentation`.
+For documentation principles, read `general/documentation.md`.
+For project-specific doc mapping, read `project/core-app/documentation.md`.
+
+Doc references in this checklist use bare paths relative to the documentation root. The audience contract — which docs a given skill must read — lives in each doc's `mandatory_for:` frontmatter and is resolved by `devwatch doc-read --skill <name> --display`. See `general/mandatory-for-schema.md`.
 
 ---
 
@@ -15,19 +22,19 @@ For project-specific doc mapping, read `docs:project/core-app/documentation`.
 
 ## Completeness
 
-- [ ] New entities are in the entity-map with paths across all layers. → `docs:project/core-app/entity-map`
-- [ ] New node types and relationships are in the graph entity model. → `docs:project/core-app/architecture/graph-entity-model`
-- [ ] New API endpoints are in the API design doc. → `docs:project/core-app/backend/api-design`
-- [ ] New agent tools are in the tools inventory. → `docs:project/core-app/agents/tools`
-- [ ] New config sections are in the configuration system doc. → `docs:project/core-app/architecture/configuration-system`
+- [ ] New entities are in the entity-map with paths across all layers. → `project/core-app/entity-map.md`
+- [ ] New node types and relationships are in the graph entity model. → `project/core-app/architecture/graph-entity-model.md`
+- [ ] New API endpoints are in the API design doc. → `project/core-app/backend/api-design.md`
+- [ ] New agent tools are in the tools inventory. → `project/core-app/agents/tools.md`
+- [ ] New config sections are in the configuration system doc. → `project/core-app/architecture/configuration-system.md`
 - [ ] New frontend stores, query keys, or routes are in the relevant frontend doc.
-- [ ] New workflow steps are in the workflows doc. → `docs:project/core-app/backend/workflows`
+- [ ] New workflow steps are in the workflows doc. → `project/core-app/backend/workflows.md`
 
 ## Consistency
 
 - [ ] No duplicated content. If the same concept is explained in two docs, one references the other — it does not re-explain.
-- [ ] Cross-references use `docs:` prefix and point to existing files.
-- [ ] Terminology matches `docs:project/core-app/product/concepts` — no old names, no ad-hoc synonyms.
+- [ ] Cross-references use bare paths and point to existing files. Run `devwatch doc-validate` to catch dangling frontmatter.
+- [ ] Terminology matches `project/core-app/product/concepts.md` — no old names, no ad-hoc synonyms.
 
 ## Structure
 
@@ -36,7 +43,17 @@ For project-specific doc mapping, read `docs:project/core-app/documentation`.
 - [ ] No filler, no hedging, no marketing language. Direct and concise.
 - [ ] Tables for structured data (properties, mappings, inventories). Prose for explanations.
 
+## Product Tier
+
+User-facing docs in `product/` have a different audience than technical docs — non-technical readers — so they need their own checks. See `general/documentation.md` for per-area writing guidance.
+
+- [ ] `product/overview.md` still reflects current product scope. Adding, removing, or repositioning a user-facing capability means updating *what the product does* and *who it's for*. → `product/overview.md`
+- [ ] New user-facing features are documented in `product/usage.md` — getting started, workflows, examples, or troubleshooting as appropriate. If a user can do something new, they should be able to find out how. → `product/usage.md`
+- [ ] Renamed or removed user-facing features are updated or removed from `product/` docs. No references to capabilities that no longer exist or names users no longer see.
+- [ ] No internal jargon, module names, file paths, class names, or code-level detail in `product/` docs. If a sentence requires reading the code to understand, rewrite it in plain language.
+- [ ] Terminology in `product/` matches what users actually see in the UI, CLI, or output — not internal entity names. If the UI says "project" but the code calls it `Workspace`, the product doc says "project."
+
 ## Rules Integration
 
-- [ ] If a new doc was created, is it referenced in the relevant `.claude/rules/` file so the agent knows to read it?
-- [ ] If a doc was moved or renamed, are all `docs:` references across all repos updated?
+- [ ] If a new doc was created, does its `mandatory_for:` frontmatter list every skill that must read it? Run `devwatch doc-read --skill <name> --display` to confirm the doc shows up where expected.
+- [ ] If a doc was moved or renamed, are all references across all repos updated? Bare paths are grep-able — search for the old path.

--- a/documentation/general/general/documentation.md
+++ b/documentation/general/general/documentation.md
@@ -1,3 +1,8 @@
+---
+mandatory_for:
+  universal: true
+---
+
 # Documentation
 
 How to write and maintain documentation. These principles apply to any project.
@@ -36,17 +41,48 @@ A doc should be readable without context. A developer opening the file for the f
 
 Docs reference each other, never duplicate each other. If concept X is explained in doc A, doc B links to doc A — it does not re-explain X.
 
-Use the `docs:` prefix convention for references: `docs:general/principles/clean-code` resolves to the actual file path. This makes references grep-able and verifiable.
+Reference docs by their bare path under the documentation root (e.g. `general/clean-code.md`). The audience contract — which docs a given skill must read — is declared in each doc's `mandatory_for:` frontmatter and resolved by `devwatch doc-read --skill <name> --display`. See `general/mandatory-for-schema.md` for the schema; `devwatch doc-validate` enforces it.
 
 ### Hierarchy
 
-Organize docs by who needs them and when:
+Docs live under `documentation/` in three top-level areas. Each area has a distinct audience and purpose — keep them separate.
 
-- **General principles** — reusable across any project. Read once, apply everywhere.
-- **Project-specific** — how this particular codebase works. Read when working in this project.
-- **Guides** — step-by-step instructions for specific tasks. Read when doing that task.
+- **`general/`** — cross-project principles, conventions, and language guides (clean code, testing, Python patterns, TypeScript patterns, checklists). Reusable across any codebase.
+- **`project/`** — developer-facing docs for *this* codebase: architecture, layer boundaries, key directories, design decisions, trade-offs.
+- **`product/`** — user-facing docs: what the product does, who it's for, and how to use it. Written for non-technical readers.
 
-A developer new to the project reads: general principles → project architecture → the specific area they are working in. The docs should support this reading order.
+Reading order for someone new to the project:
+
+1. `general/` — how we write code in general (only the parts relevant to the area you will touch).
+2. `project/` — how *this* codebase is structured and why.
+3. `product/` — what the product is and who uses it, if the work needs that context.
+
+A developer fixing a bug typically needs `general/` + `project/`. Someone writing release notes or user-facing copy needs `product/`. An AI agent onboarding to the repo should read in the same order, scoped to the area it is about to modify.
+
+## Per-Area Writing Guidance
+
+Each area has a different audience. What belongs in one does not belong in the others.
+
+### `general/`
+
+- **Audience**: developers and AI agents, across any project using these templates.
+- **Scope**: principles, patterns, conventions, checklists that hold regardless of the specific codebase.
+- **Tone**: direct, prescriptive, example-driven. State the rule, show a short example, explain *why*.
+- **Avoid**: references to this project's directories, entities, or business logic. If a doc only makes sense in one codebase, it belongs in `project/`, not here.
+
+### `project/`
+
+- **Audience**: developers and AI agents working in this specific codebase.
+- **Scope**: architecture, module boundaries, data flow, the real names of entities and services, decisions specific to this project and the trade-offs behind them.
+- **Tone**: concrete and specific. Name real files, real modules, real tables. Explain *why* this codebase is shaped this way.
+- **Avoid**: restating general principles already in `general/` — link to them. Avoid user-facing framing ("what the product does") — that belongs in `product/`.
+
+### `product/`
+
+- **Audience**: non-technical readers — end users, stakeholders, new hires before they touch the code.
+- **Scope**: what the product is, who it's for, the problem it solves, how to use it, common workflows, examples, troubleshooting.
+- **Tone**: plain language. Short sentences. Concrete outcomes ("upload a file and get a summary"), not implementation ("the ingest pipeline writes to the blob store").
+- **Avoid**: internal jargon, module names, class names, file paths, API signatures, database terms, code snippets beyond what a user would paste into a UI. If a reader needs to know the codebase to understand a sentence, rewrite the sentence.
 
 ## Tone
 

--- a/documentation/general/general/github-writing.md
+++ b/documentation/general/general/github-writing.md
@@ -1,3 +1,8 @@
+---
+mandatory_for:
+  universal: true
+---
+
 # GitHub Writing
 
 Rules for anything an agent writes into GitHub — issue titles, issue bodies, PR titles, PR bodies, and comments. Applies to both human-triggered and autonomous runs.

--- a/documentation/general/general/issue-to-rule.md
+++ b/documentation/general/general/issue-to-rule.md
@@ -1,3 +1,8 @@
+---
+mandatory_for:
+  skills: [issue-to-rule]
+---
+
 # Issue to Rule
 
 When a resolved issue reveals a **class of mistake** — not a single incident — capture the underlying constraint as a persistent rule so the same mistake does not recur. Rule feedback is about text, not code: the fix lives in the code, the **lesson** lives in `.claude/rules/` or a principle doc.

--- a/documentation/general/general/propagation-scan.md
+++ b/documentation/general/general/propagation-scan.md
@@ -1,3 +1,8 @@
+---
+mandatory_for:
+  skills: [propagation-scan]
+---
+
 # Propagation Scan
 
 After you land a change, ask: *is this fix or helper useful anywhere else?* Propagation scanning is the reflex that answers that question systematically — without violating scope hygiene.

--- a/documentation/general/general/rules-checklist.md
+++ b/documentation/general/general/rules-checklist.md
@@ -1,3 +1,8 @@
+---
+mandatory_for:
+  skills: [issue-to-rule]
+---
+
 # Rules Checklist
 
 Run through this checklist before adding or updating a rule. Every item is a yes/no question. Used by the `/issue-to-rule` skill as a mechanical verifier gate — if any item fails, the rule does not ship.
@@ -19,7 +24,7 @@ For rule-authoring principles, read [Writing rules](vibe-coding/rules). For the 
   - `general/` (or `_shared_docs/general/`) — declarative, portable, applies to any project
   - `.claude/rules/critical.md` (project-level) — always-loaded, project-specific guardrails
   - `.claude/rules/<domain>.md` — scope-loaded, applies when touching `<domain>` files
-- [ ] Every `docs:` reference in the rule resolves to an existing file, or to a path the same change commits to create.
+- [ ] Every doc path referenced in the rule exists, or is a path the same change commits to create. If the rule adds a new doc under `documentation/`, its `mandatory_for:` frontmatter validates with `devwatch doc-validate`.
 - [ ] If the rule adds a new artifact (doc, CLI command, endpoint), the corresponding doc/checklist is listed in the mutation set.
 
 ## Consistency

--- a/documentation/general/python/architecture.md
+++ b/documentation/general/python/architecture.md
@@ -1,3 +1,9 @@
+---
+mandatory_for:
+  skills: [fix-issue, feat-issue]
+  rules: [backend]
+---
+
 # Python Backend Architecture
 
 Guidelines for structuring Python backend applications using layered architecture, dependency inversion, and clean module organization.
@@ -96,6 +102,21 @@ class UserService:
         return created
 ```
 
+### Framework-Level Injection
+
+Web framework dependency injection (e.g., FastAPI's `Depends()`) handles HTTP-level concerns: authentication, request context, database sessions. Keep this at the API layer only.
+
+```python
+# api/endpoints/user_endpoints.py
+from fastapi import APIRouter, Depends
+
+router = APIRouter()
+
+@router.get("/users/{uuid}")
+def get_user(uuid: str, service: UserService = Depends(get_user_service)):
+    return service.get_user(uuid)
+```
+
 ### Singleton and Proxy Patterns
 
 Expensive resources (database connections, event publishers) use the singleton pattern -- instantiated once at startup, shared across the application.
@@ -179,3 +200,98 @@ Rules:
 - No star imports (`from module import *`) in production code.
 - Group related concepts into sub-packages: `services/document/`, `services/user/`.
 
+## Standard CRUD Interface
+
+Repository interfaces follow a consistent method signature pattern:
+
+| Method | Signature | Returns |
+|---|---|---|
+| `create` | `create(entity: T) -> T` | Created entity |
+| `get_by_uuid` | `get_by_uuid(uuid: str) -> T \| None` | Entity or None |
+| `get_by_<field>` | `get_by_email(email: str) -> T \| None` | Entity or None |
+| `get_all` | `get_all(scope: str) -> list[T]` | List of entities |
+| `update` | `update(entity: T) -> T` | Updated entity |
+| `delete` | `delete(uuid: str) -> None` | Nothing |
+| `count` | `count(scope: str) -> int` | Count |
+
+The interface lives in the domain layer. The implementation lives in infrastructure. The service instantiates the concrete repository in its constructor (or receives it via injection).
+
+## No String Literals in Queries
+
+Every entity name, table name, collection name, node label, or relationship type that appears in a database query must come from a constant or enum — never a raw string literal. This applies regardless of database technology (SQL, Cypher, MongoDB, Elasticsearch).
+
+Define constants in the domain layer (e.g., `domain/constants/`). Repository implementations import and use them:
+
+```python
+# domain/constants/schema.py
+from enum import StrEnum
+
+class NodeType(StrEnum):
+    USER = "User"
+    DOCUMENT = "Document"
+    TAG = "Tag"
+
+class RelType(StrEnum):
+    HAS_TAG = "HAS_TAG"
+    BELONGS_TO = "BELONGS_TO"
+
+# For SQL:
+class TableName(StrEnum):
+    USERS = "users"
+    DOCUMENTS = "documents"
+```
+
+```python
+# Good — constants
+from domain.constants.schema import NodeType
+
+result = connector.execute(
+    f"MATCH (u:{NodeType.USER} {{uuid: $uuid}}) RETURN u",
+    uuid=uuid,
+)
+
+# Bad — string literals
+result = connector.execute(
+    "MATCH (u:User {uuid: $uuid}) RETURN u",  # "User" is a magic string
+    uuid=uuid,
+)
+```
+
+Why this matters:
+- Renaming an entity updates one constant, not every query that mentions it.
+- Typos in constants fail at import time. Typos in strings fail at query time (or silently return empty results).
+- A grep for `NodeType.USER` finds every query that touches users. A grep for `"User"` finds everything — logs, comments, unrelated strings.
+
+This is an instance of Pillar 6 (Decouple Everything) applied to database queries — the query does not hardcode knowledge about the schema; it references the schema through a constant.
+
+### Reserved Keyword Collisions
+
+Some database engines (notably LadybugDB) fail when property names collide with query language reserved keywords. For example, `a.order` fails because `ORDER` is a Cypher reserved keyword. Either escape with backticks (`` a.`order` ``) or, better, avoid the collision entirely by naming the property `sort_order` or `display_order`. This applies to any property matching a reserved keyword (`ORDER`, `MATCH`, `RETURN`, `WHERE`, `SET`, `DELETE`, etc.).
+
+## Repository Implementation
+
+```python
+# infrastructure/graph/repositories/graph_user_repository.py
+from domain.constants.schema import NodeType
+from domain.repositories.user_repository import IUserRepository
+
+class GraphUserRepository(IUserRepository):
+    def __init__(self, connector: DatabaseConnector) -> None:
+        self._connector = connector
+
+    def get_by_uuid(self, uuid: str) -> User | None:
+        result = self._connector.execute(
+            f"MATCH (u:{NodeType.USER} {{uuid: $uuid}}) RETURN u",
+            uuid=uuid,
+        )
+        if not result:
+            return None
+        return User.from_record(result[0])
+
+    def create(self, user: User) -> User:
+        self._connector.execute(
+            f"CREATE (u:{NodeType.USER} {{uuid: $uuid, name: $name, email: $email}})",
+            uuid=user.uuid, name=user.name, email=user.email,
+        )
+        return user
+```

--- a/documentation/general/python/checklist.md
+++ b/documentation/general/python/checklist.md
@@ -1,3 +1,9 @@
+---
+mandatory_for:
+  skills: [check-code-quality]
+  rules: [backend]
+---
+
 # Python Completion Checklist
 
 Run the [general checklist](../checklist) first, then this one.
@@ -13,9 +19,10 @@ Run the [general checklist](../checklist) first, then this one.
 
 ## Architecture
 
-- [ ] Interfaces (ABCs) live next to the abstractions they define; concrete implementations depend on interfaces, not vice versa. → [Interface-First Design](architecture#interface-first-design)
-- [ ] Dependencies injected via constructor. No global singletons reached through module-level state. → [Dependency Injection](architecture#dependency-injection)
-- [ ] Module organisation prefers depth over flat dumps; every package has explicit `__all__` in `__init__.py`. → [Module Organization](architecture#module-organization)
+- [ ] Business logic in services only. API endpoints are thin (parse request → call service → return response). → [Layered Architecture](architecture#layered-architecture)
+- [ ] Repository interfaces in domain layer (ABC). Implementations in infrastructure layer. → [Interface-First Design](architecture#interface-first-design)
+- [ ] Import direction is strictly downward: API → Application → Infrastructure → Domain. No upward imports. → [Layered Architecture](architecture#layered-architecture)
+- [ ] All database entity names (node labels, table names, relationship types) use constants/enums, never string literals. → [No String Literals in Queries](architecture#no-string-literals-in-queries)
 
 ## Patterns
 
@@ -34,9 +41,11 @@ Run the [general checklist](../checklist) first, then this one.
 - [ ] Logging uses `%s` parameterized format, not f-strings. → [Logging](conventions#logging)
 - [ ] `__init__.py` has explicit `__all__`. No star imports. → [\_\_init\_\_.py Pattern](conventions#__init__py-pattern)
 
-## Secrets
+## Security
 
-- [ ] No API keys, tokens, or credentials in code or YAML. Always loaded from environment (`OPENAI_API_KEY`, etc.).
+- [ ] No secrets in code. All from environment variables. → [Secrets Management](security#secrets-management)
+- [ ] Paths built with `pathlib.Path`, never string concatenation. → [Input Validation](security#input-validation)
+- [ ] Upload sizes validated before reading full payload. → [Input Validation](security#input-validation)
 
 ## Observability
 

--- a/documentation/general/python/conventions.md
+++ b/documentation/general/python/conventions.md
@@ -1,3 +1,9 @@
+---
+mandatory_for:
+  skills: [fix-issue, feat-issue]
+  rules: [backend]
+---
+
 # Python Coding Conventions
 
 General-purpose conventions for Python projects. Use as a reference while writing code.

--- a/documentation/general/python/patterns.md
+++ b/documentation/general/python/patterns.md
@@ -1,3 +1,9 @@
+---
+mandatory_for:
+  skills: [fix-issue, feat-issue]
+  rules: [backend]
+---
+
 # Python Patterns
 
 Reusable patterns for modern Python applications. Framework-agnostic where possible.
@@ -85,6 +91,19 @@ Minimal exception types. No deep custom hierarchies unless genuinely needed.
 | `ValueError` | Client error — bad input, missing entity | 400 |
 | `RuntimeError` | Server error — unexpected failure | 500 |
 
+### Global exception handler
+
+```python
+@app.exception_handler(ValueError)
+async def value_error_handler(request, exc):
+    return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+@app.exception_handler(RuntimeError)
+async def runtime_error_handler(request, exc):
+    logger.error("Unexpected error", exc_info=exc)
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+```
+
 ### Exception chaining
 
 Always preserve the original cause:
@@ -106,6 +125,23 @@ def require_entity(value: T | None, name: str, identifier: str) -> T:
 
 # Usage — one-liner guard
 entity = require_entity(await repo.get_by_id(uuid), "Entity", uuid)
+```
+
+### Decorator for endpoint error wrapping
+
+```python
+from functools import wraps
+
+def handle_service_errors(fn):
+    @wraps(fn)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await fn(*args, **kwargs)
+        except ValueError:
+            raise  # let global handler convert to 400
+        except Exception as e:
+            raise RuntimeError(f"Unexpected error in {fn.__name__}") from e
+    return wrapper
 ```
 
 ---

--- a/documentation/general/python/testing.md
+++ b/documentation/general/python/testing.md
@@ -1,3 +1,8 @@
+---
+mandatory_for:
+  skills: [check-code-quality]
+---
+
 # Python Testing
 
 ## pytest Ecosystem

--- a/documentation/general/python/typing.md
+++ b/documentation/general/python/typing.md
@@ -1,3 +1,9 @@
+---
+mandatory_for:
+  skills: [fix-issue, feat-issue]
+  rules: [backend]
+---
+
 # Python Typing
 
 ## Strict Type Checking

--- a/documentation/project/capabilities.md
+++ b/documentation/project/capabilities.md
@@ -35,6 +35,8 @@ The full surface lives in `sinan_agentic_core/core/capabilities/base.py`:
 | `on_tool_end(ctx, tool, result)` | Tool finished |
 | `on_llm_start(ctx, agent, system_prompt, input_items)` | Model call begins |
 | `on_llm_end(ctx, agent, response)` | Model call returns |
+| `on_fallback_start(ctx, prompt, collected_items)` | Recovery branch of `_execute_with_fallback` is about to send its condensed chat-completions call (after the agent loop raised `Max turns` / `context_length_exceeded`) |
+| `on_fallback_end(ctx, response, usage)` | Recovery LLM call returned, before output-type parsing |
 | `tools()` | Extra tools the capability exposes to the agent |
 | `reset()` | Called at the start of every `execute()` - clear mutable state |
 | `clone()` | Per-run copy; default is `copy.deepcopy(self)` |
@@ -77,6 +79,27 @@ final_output (caps still hold post-run state for inspection)
 The cloning rule is the key isolation guarantee: declarative capabilities on
 `AgentDefinition` are templates, the runner clones them per call, so two
 concurrent runs never share `turns_used` or error history.
+
+### Fallback recovery hooks
+
+`fallback_on_overflow=True` enables a recovery branch in `_execute_with_fallback`
+that catches `Max turns` / `context_length_exceeded` from the agent loop and
+makes a single condensed chat-completions call to rescue the run. That call
+bypasses `Runner.run`, so the SDK lifecycle hooks (`on_agent_start`,
+`on_tool_start`, etc.) do not fire on it. Two dedicated hooks cover the gap:
+
+- `on_fallback_start(ctx, prompt, collected_items)` — fires after the recovery
+  prompt is built and before the chat-completions request is sent. Use it to
+  audit-log the fallback prompt, count fallbacks, or capture the gathered tool
+  outputs.
+- `on_fallback_end(ctx, response, usage)` — fires after the recovery call
+  returns and before any output-type parsing. Use it to inspect or validate
+  rescued outputs (typically the most interesting runs — they nearly failed).
+
+Tool-event hooks are intentionally **not** fired on the recovery branch: no
+tools are invoked there, so dispatching them would be misleading. The hooks
+also do not fire on the normal-success path of `_execute_with_fallback` — only
+when the recovery branch actually runs.
 
 ## Writing a custom capability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sinan-agentic-core"
-version = "0.9.1"
+version = "0.11.0"
 description = "State-of-the-art framework for building AI agents with OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sinan_agentic_core/core/base_runner.py
+++ b/sinan_agentic_core/core/base_runner.py
@@ -396,6 +396,9 @@ class BaseAgentRunner:
             builder = fallback_prompt_builder or self._default_fallback_prompt_builder
             prompt = builder(instructions, collecting.raw_items, agent_def)
 
+            for cap in capabilities:
+                cap.on_fallback_start(ctx_wrapper, prompt, collecting.raw_items)
+
             from agents.models._openai_shared import get_default_openai_key
             from openai import AsyncOpenAI
 
@@ -443,8 +446,9 @@ class BaseAgentRunner:
             content = response.choices[0].message.content
 
             # Capture fallback usage from the direct LLM call
+            fallback_usage: dict[str, Any] | None = None
             if response.usage:
-                self.last_usage = {
+                fallback_usage = {
                     "requests": 1,
                     "input_tokens": response.usage.prompt_tokens or 0,
                     "output_tokens": response.usage.completion_tokens or 0,
@@ -452,6 +456,10 @@ class BaseAgentRunner:
                     "input_tokens_details": {"cached_tokens": 0},
                     "output_tokens_details": {"reasoning_tokens": 0},
                 }
+                self.last_usage = fallback_usage
+
+            for cap in capabilities:
+                cap.on_fallback_end(ctx_wrapper, content, fallback_usage)
 
             if not use_json:
                 return content

--- a/sinan_agentic_core/core/base_runner.py
+++ b/sinan_agentic_core/core/base_runner.py
@@ -361,14 +361,20 @@ class BaseAgentRunner:
         collecting = _CollectingSessionWrapper(session)
         logger.info(f"Running agent with fallback: {agent_name}")
 
+        run_kwargs: dict[str, Any] = {
+            "starting_agent": agent,
+            "input": input_text,
+            "session": collecting,
+            "context": context,
+            "max_turns": max_turns,
+        }
+
+        hooks = self._build_hooks(capabilities)
+        if hooks:
+            run_kwargs["hooks"] = hooks
+
         try:
-            run_result = await Runner.run(
-                starting_agent=agent,
-                input=input_text,
-                session=collecting,
-                context=context,
-                max_turns=max_turns,
-            )
+            run_result = await Runner.run(**run_kwargs)
             self.last_usage = self._aggregate_usage(run_result)
             logger.info(f"Agent '{agent_name}' completed successfully")
             return run_result.final_output

--- a/sinan_agentic_core/core/capabilities/base.py
+++ b/sinan_agentic_core/core/capabilities/base.py
@@ -115,6 +115,43 @@ class Capability:
         """Called immediately after the model returns a response."""
         return None
 
+    def on_fallback_start(
+        self,
+        ctx: RunContextWrapper[Any],
+        prompt: str,
+        collected_items: list[Any],
+    ) -> None:
+        """Called immediately before the summarize-and-extract recovery LLM call.
+
+        Fires only on the recovery branch of ``_execute_with_fallback`` — when
+        the agent loop has raised a recoverable overflow (``Max turns`` /
+        ``context_length_exceeded``) and the runner is about to send a single
+        condensed chat-completions request that bypasses ``Runner.run``.
+
+        ``prompt`` is the fully-rendered recovery prompt; ``collected_items``
+        is the list of raw session items gathered during the failed agent
+        loop (the same list passed to the fallback-prompt builder). Tool-event
+        hooks (``on_tool_start`` / ``on_tool_end``) are intentionally **not**
+        fired on this path — no tools are invoked.
+        """
+        return None
+
+    def on_fallback_end(
+        self,
+        ctx: RunContextWrapper[Any],
+        response: str | None,
+        usage: dict[str, Any] | None,
+    ) -> None:
+        """Called immediately after the recovery LLM call returns.
+
+        Fires only on the recovery branch of ``_execute_with_fallback``,
+        before any output-type parsing. ``response`` is the raw assistant
+        message content from the chat-completions call (``None`` if the
+        provider returned no content); ``usage`` is the token-usage dict
+        captured from the response (``None`` if the provider omitted it).
+        """
+        return None
+
     def reset(self) -> None:
         """Reset mutable state. Called at the start of each ``execute()`` call."""
         return None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -707,6 +707,113 @@ class TestExecuteWithFallback:
         assert isinstance(captured_hooks["hooks"], _CompositeHooks)
         assert recorded_tool_starts == ["test_tool"]
 
+    async def test_recovery_branch_fires_fallback_hooks(self, runner):
+        """Recovery branch invokes on_fallback_start / on_fallback_end on capabilities.
+
+        Tool-event hooks must NOT fire on the recovery branch (no tools run).
+        """
+        from sinan_agentic_core.core.capabilities import Capability
+
+        class _RecorderCapability(Capability):
+            def __init__(self):
+                self.starts: list[tuple[str, list]] = []
+                self.ends: list[tuple[str | None, dict | None]] = []
+                self.tool_starts: list[str] = []
+                self.tool_ends: list[str] = []
+
+            def on_fallback_start(self, ctx, prompt, collected_items):
+                self.starts.append((prompt, list(collected_items)))
+
+            def on_fallback_end(self, ctx, response, usage):
+                self.ends.append((response, usage))
+
+            def on_tool_start(self, ctx, tool, args):
+                self.tool_starts.append(getattr(tool, "name", "?"))
+
+            def on_tool_end(self, ctx, tool, result):
+                self.tool_ends.append(str(result))
+
+        recorder = _RecorderCapability()
+        ctx = AgentContext(database_connector=Mock())
+        session = AgentSession(session_id="test")
+
+        mock_completion = Mock()
+        mock_completion.choices = [Mock()]
+        mock_completion.choices[0].message.content = "Rescued output"
+        mock_completion.usage = Mock(prompt_tokens=100, completion_tokens=20, total_tokens=120)
+
+        with (
+            patch.object(runner, "create_agent", new_callable=AsyncMock, return_value=Mock()),
+            patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
+            patch("openai.AsyncOpenAI") as mock_openai,
+        ):
+            mock_runner_cls.run = AsyncMock(side_effect=RuntimeError("Max turns exceeded"))
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+            mock_openai.return_value = mock_client
+
+            result = await runner._execute_with_fallback(
+                "basic_agent",
+                ctx,
+                session,
+                10,
+                "hello",
+                None,
+                capabilities=[recorder],
+            )
+
+        assert result == "Rescued output"
+        assert len(recorder.starts) == 1
+        prompt, collected_items = recorder.starts[0]
+        assert "You are a basic agent" in prompt
+        assert isinstance(collected_items, list)
+        assert len(recorder.ends) == 1
+        response, usage = recorder.ends[0]
+        assert response == "Rescued output"
+        assert usage is not None
+        assert usage["input_tokens"] == 100
+        assert usage["output_tokens"] == 20
+        # Tool-event hooks must NOT fire on the recovery branch.
+        assert recorder.tool_starts == []
+        assert recorder.tool_ends == []
+
+    async def test_normal_success_path_does_not_fire_fallback_hooks(self, runner, mock_run_result):
+        """When Runner.run succeeds, fallback hooks must not fire."""
+        from sinan_agentic_core.core.capabilities import Capability
+
+        class _Recorder(Capability):
+            def __init__(self):
+                self.start_calls = 0
+                self.end_calls = 0
+
+            def on_fallback_start(self, ctx, prompt, collected_items):
+                self.start_calls += 1
+
+            def on_fallback_end(self, ctx, response, usage):
+                self.end_calls += 1
+
+        recorder = _Recorder()
+        ctx = AgentContext(database_connector=Mock())
+        session = AgentSession(session_id="test")
+
+        with (
+            patch.object(runner, "create_agent", new_callable=AsyncMock, return_value=Mock()),
+            patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
+        ):
+            mock_runner_cls.run = AsyncMock(return_value=mock_run_result)
+            await runner._execute_with_fallback(
+                "basic_agent",
+                ctx,
+                session,
+                10,
+                "hello",
+                None,
+                capabilities=[recorder],
+            )
+
+        assert recorder.start_calls == 0
+        assert recorder.end_calls == 0
+
     async def test_normal_path_omits_hooks_when_no_capabilities(self, runner, mock_run_result):
         """No hooks kwarg is passed when there are no capabilities."""
         ctx = AgentContext(database_connector=Mock())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -659,6 +659,72 @@ class TestExecuteWithFallback:
 
         assert result == "Plain text fallback"
 
+    async def test_normal_path_wires_capability_hooks(self, runner, mock_run_result):
+        """Capability lifecycle hooks fire on the normal-success fallback path."""
+        from sinan_agentic_core.core.base_runner import _CompositeHooks
+        from sinan_agentic_core.core.capabilities import Capability
+
+        recorded_tool_starts: list[str] = []
+
+        class _RecorderCapability(Capability):
+            def on_tool_start(self, ctx, tool, args):
+                recorded_tool_starts.append(getattr(tool, "name", "unknown"))
+
+        recorder = _RecorderCapability()
+        ctx = AgentContext(database_connector=Mock())
+        session = AgentSession(session_id="test")
+
+        captured_hooks: dict[str, object] = {}
+
+        async def _fake_run(**kwargs):
+            captured_hooks["hooks"] = kwargs.get("hooks")
+            hooks = kwargs.get("hooks")
+            if hooks is not None:
+                fake_tool = Mock()
+                fake_tool.name = "test_tool"
+                fake_ctx = Mock()
+                fake_ctx.tool_arguments = ""
+                await hooks.on_tool_start(fake_ctx, Mock(), fake_tool)
+            return mock_run_result
+
+        with (
+            patch.object(runner, "create_agent", new_callable=AsyncMock, return_value=Mock()),
+            patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
+        ):
+            mock_runner_cls.run = AsyncMock(side_effect=_fake_run)
+
+            result = await runner._execute_with_fallback(
+                "basic_agent",
+                ctx,
+                session,
+                10,
+                "hello",
+                None,
+                capabilities=[recorder],
+            )
+
+        assert result == "Test response"
+        assert isinstance(captured_hooks["hooks"], _CompositeHooks)
+        assert recorded_tool_starts == ["test_tool"]
+
+    async def test_normal_path_omits_hooks_when_no_capabilities(self, runner, mock_run_result):
+        """No hooks kwarg is passed when there are no capabilities."""
+        ctx = AgentContext(database_connector=Mock())
+        session = AgentSession(session_id="test")
+
+        with (
+            patch.object(runner, "create_agent", new_callable=AsyncMock, return_value=Mock()),
+            patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
+        ):
+            mock_runner_cls.run = AsyncMock(return_value=mock_run_result)
+
+            await runner._execute_with_fallback(
+                "basic_agent", ctx, session, 10, "hello", None, capabilities=[]
+            )
+
+            call_kwargs = mock_runner_cls.run.call_args.kwargs
+            assert "hooks" not in call_kwargs
+
 
 # ------------------------------------------------------------------ #
 # _default_fallback_prompt_builder


### PR DESCRIPTION
## Highlights

- **feat(core):** `Capability` protocol gains `on_fallback_start` / `on_fallback_end` hooks so capabilities can observe the summarize-and-extract recovery branch in `BaseAgentRunner._execute_with_fallback`. Default no-ops keep existing capabilities working unchanged. (#30)
- **fix(core):** Wire capability hooks into the fallback runner's normal-execution path so hook-based capabilities are no longer silenced on `execute()`. (#29)

## Chores

- Skill templates and the `doc-read` framework refreshed from devwatch (`v1.101.0`+).