### PR TITLE
Release: staging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sinan-agentic-core"
-version = "0.11.0"
+version = "0.11.1"
 description = "State-of-the-art framework for building AI agents with OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sinan_agentic_core/core/base_runner.py
+++ b/sinan_agentic_core/core/base_runner.py
@@ -399,11 +399,13 @@ class BaseAgentRunner:
             for cap in capabilities:
                 cap.on_fallback_start(ctx_wrapper, prompt, collecting.raw_items)
 
-            from agents.models._openai_shared import get_default_openai_key
-            from openai import AsyncOpenAI
+            from agents.models._openai_shared import get_default_openai_client
 
-            api_key = get_default_openai_key()
-            client = AsyncOpenAI(api_key=api_key)
+            client = get_default_openai_client()
+            if client is None:
+                from openai import AsyncOpenAI
+
+                client = AsyncOpenAI()
 
             output_type = self._resolve_output_type(agent_def.output_dataclass)
             use_json = output_type and output_type is not str

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -832,6 +832,99 @@ class TestExecuteWithFallback:
             call_kwargs = mock_runner_cls.run.call_args.kwargs
             assert "hooks" not in call_kwargs
 
+    async def test_recovery_branch_reuses_configured_default_client(self, runner):
+        """Recovery branch routes the rescue call through the SDK's configured
+        default client (e.g. AsyncAzureOpenAI) instead of constructing a fresh
+        AsyncOpenAI. Regression for #35.
+        """
+        from sinan_agentic_core.core.capabilities import Capability
+
+        class _Recorder(Capability):
+            def __init__(self):
+                self.start_calls = 0
+                self.end_calls = 0
+
+            def on_fallback_start(self, ctx, prompt, collected_items):
+                self.start_calls += 1
+
+            def on_fallback_end(self, ctx, response, usage):
+                self.end_calls += 1
+
+        recorder = _Recorder()
+        ctx = AgentContext(database_connector=Mock())
+        session = AgentSession(session_id="test")
+
+        mock_completion = Mock()
+        mock_completion.choices = [Mock()]
+        mock_completion.choices[0].message.content = "Rescued via Azure"
+        mock_completion.usage = Mock(prompt_tokens=50, completion_tokens=10, total_tokens=60)
+
+        configured_client = AsyncMock(name="AsyncAzureOpenAI")
+        configured_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        with (
+            patch.object(runner, "create_agent", new_callable=AsyncMock, return_value=Mock()),
+            patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
+            patch(
+                "agents.models._openai_shared.get_default_openai_client",
+                return_value=configured_client,
+            ),
+            patch("openai.AsyncOpenAI") as mock_async_openai,
+        ):
+            mock_runner_cls.run = AsyncMock(side_effect=RuntimeError("Max turns (2) exceeded"))
+
+            result = await runner._execute_with_fallback(
+                "basic_agent",
+                ctx,
+                session,
+                2,
+                "hello",
+                None,
+                capabilities=[recorder],
+            )
+
+        assert result == "Rescued via Azure"
+        configured_client.chat.completions.create.assert_awaited_once()
+        # Must NOT have built a fresh AsyncOpenAI when a default is configured.
+        mock_async_openai.assert_not_called()
+        # Capability hooks still fire exactly once each, in order.
+        assert recorder.start_calls == 1
+        assert recorder.end_calls == 1
+
+    async def test_recovery_branch_falls_back_to_async_openai_when_no_default(self, runner):
+        """When no default client is configured, fall back to constructing
+        AsyncOpenAI() with no api_key kwarg (the SDK reads OPENAI_API_KEY).
+        Regression for #35 — must not pass api_key=None into AsyncOpenAI().
+        """
+        ctx = AgentContext(database_connector=Mock())
+        session = AgentSession(session_id="test")
+
+        mock_completion = Mock()
+        mock_completion.choices = [Mock()]
+        mock_completion.choices[0].message.content = "Rescued via OpenAI"
+        mock_completion.usage = Mock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+        with (
+            patch.object(runner, "create_agent", new_callable=AsyncMock, return_value=Mock()),
+            patch("sinan_agentic_core.core.base_runner.Runner") as mock_runner_cls,
+            patch(
+                "agents.models._openai_shared.get_default_openai_client",
+                return_value=None,
+            ),
+            patch("openai.AsyncOpenAI") as mock_async_openai,
+        ):
+            mock_runner_cls.run = AsyncMock(side_effect=RuntimeError("Max turns exceeded"))
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+            mock_async_openai.return_value = mock_client
+
+            result = await runner._execute_with_fallback(
+                "basic_agent", ctx, session, 10, "hello", None
+            )
+
+        assert result == "Rescued via OpenAI"
+        mock_async_openai.assert_called_once_with()
+
 
 # ------------------------------------------------------------------ #
 # _default_fallback_prompt_builder

--- a/uv.lock
+++ b/uv.lock
@@ -1504,7 +1504,7 @@ wheels = [
 
 [[package]]
 name = "sinan-agentic-core"
-version = "0.9.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
### Fixes

- Fallback recovery in `BaseAgentRunner._execute_with_fallback` now reuses the configured default OpenAI client (via `get_default_openai_client()`) instead of rebuilding a plain `AsyncOpenAI` from `get_default_openai_key()`. Azure-configured agents no longer crash with `openai.OpenAIError` before issuing the rescue call. (#35)